### PR TITLE
fix incorrect itemPickup debug arguments

### DIFF
--- a/src/client/gamehooks.cpp
+++ b/src/client/gamehooks.cpp
@@ -47,7 +47,7 @@ typedef void(__fastcall *ItemPickupFn)(void *rcx, int edx, int r8);
 static ItemPickupFn oItemPickup = nullptr;
 void __fastcall GameHooks::onItemPickup(void *MaybeInventoryStruct, int ItemID, int NumItems)
 {
-    logDebug("[gamehooks] ItemPickup called with 0x%p, 0x%X, 0x%X", ItemID, NumItems);
+    logDebug("[gamehooks] ItemPickup called with 0x%p, 0x%X, 0x%X", MaybeInventoryStruct, ItemID, NumItems);
     if (NumItems > 0)
     {
         if (checkItems(ItemID))


### PR DESCRIPTION
## Description
Fixes a small bug reported by @Void-bits in the itemPickup debug message

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [ ] Mod loads in-game
- [ ] Feature works as expected
- [ ] Ran `./format.sh`

## Related Issues
N/A

## Screenshots/Videos
N/A

---

<!-- Thanks for contributing! -->
