### PR TITLE
Fix mutex deadlock, add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+---
+Checks: >
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-narrowing-conversions,
+  -bugprone-suspicious-stringview-data-usage,
+  performance-*,
+  -performance-avoid-endl,
+  -performance-no-int-to-ptr,
+  modernize-use-nullptr,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+
+WarningsAsErrors: ""
+HeaderFilterRegex: ".*src/.*"
+FormatStyle: file
+
+CheckOptions:
+  - key: performance-for-range-copy.WarnOnAllAutoCopies
+    value: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,12 +5,25 @@ Checks: >
   -bugprone-exception-escape,
   -bugprone-narrowing-conversions,
   -bugprone-suspicious-stringview-data-usage,
+  -bugprone-switch-missing-default-case,
   performance-*,
   -performance-avoid-endl,
   -performance-no-int-to-ptr,
+  -performance-unnecessary-value-param,
   modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-emplace,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-redundant-*,
+  readability-simplify-boolean-expr,
+  readability-string-compare,
+  misc-unused-parameters,
+  misc-unused-using-decls,
+  misc-redundant-expression,
   clang-analyzer-*,
-  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -clang-analyzer-optin.performance.Padding
 
 WarningsAsErrors: ""
 HeaderFilterRegex: ".*src/.*"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,6 +79,26 @@
             }
         },
         {
+            "name": "x64-clang-debug-analysis",
+            "displayName": "x64 Debug (Clang) + Static Analysis",
+            "inherits": "x64-clang-debug",
+            "cacheVariables": {
+                "ENABLE_CLANG_TIDY": "ON",
+                "ENABLE_CPPCHECK": "ON",
+                "STATIC_ANALYSIS_AS_ERRORS": "OFF"
+            }
+        },
+        {
+            "name": "x64-clang-debug-analysis-strict",
+            "displayName": "x64 Debug (Clang) + Static Analysis (Errors)",
+            "inherits": "x64-clang-debug",
+            "cacheVariables": {
+                "ENABLE_CLANG_TIDY": "ON",
+                "ENABLE_CPPCHECK": "ON",
+                "STATIC_ANALYSIS_AS_ERRORS": "ON"
+            }
+        },
+        {
             "name": "linux-native-base",
             "hidden": true,
             "generator": "Ninja",
@@ -167,6 +187,22 @@
                 "all"
             ],
             "configuration": "Debug"
+        },
+        {
+            "name": "x64-clang-debug-analysis",
+            "configurePreset": "x64-clang-debug-analysis",
+            "description": "Build with static analysis enabled",
+            "targets": [
+                "all"
+            ]
+        },
+        {
+            "name": "x64-clang-debug-scan-build",
+            "configurePreset": "x64-clang-debug",
+            "description": "Run comprehensive scan-build analysis",
+            "targets": [
+                "scan-build"
+            ]
         }
     ],
     "vendor": {

--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -1,3 +1,13 @@
+# Static Analysis Options
+option(ENABLE_CLANG_TIDY "Enable clang-tidy during build" OFF)
+option(ENABLE_CPPCHECK "Enable cppcheck during build" OFF)
+option(STATIC_ANALYSIS_AS_ERRORS "Treat static analysis warnings as errors" OFF)
+
+# Find static analysis tools
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+find_program(CPPCHECK_EXE NAMES "cppcheck")
+find_program(SCAN_BUILD_EXE NAMES "scan-build")
+
 function(enable_strict_warnings target)
     set_property(GLOBAL PROPERTY ENABLE_STRICT_WARNINGS_DEFINED TRUE)
     get_target_property(target_type ${target} TYPE)
@@ -18,9 +28,11 @@ function(enable_strict_warnings target)
             target_compile_options(${target} PRIVATE -Wextra -Wshadow -Wconversion)
         endif()
 
-        if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
-            # target_compile_options(${target} PRIVATE -Werror)
-        endif()
+        # Add threading-specific warnings for GCC
+        target_compile_options(${target} PRIVATE
+            -Wthread-safety
+            -Wno-thread-safety-analysis # Can be noisy, enable selectively
+        )
 
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
         target_compile_options(${target} PRIVATE /W4 /permissive-)
@@ -48,19 +60,114 @@ function(enable_strict_warnings target)
                     /clang:-Wpragma-pack
                 )
             endif()
+
+            # Add threading-specific warnings for Clang
+            target_compile_options(${target} PRIVATE
+                /clang:-Wthread-safety
+                /clang:-Wthread-safety-analysis
+                /clang:-Wthread-safety-precise
+                /clang:-Wthread-safety-reference
+                /clang:-Wthread-safety-beta
+            )
         endif()
 
         if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
-            # target_compile_options(${target} PRIVATE /WX)
+            # target_compile_options(${target} PRIVATE -Werror)
+        endif()
+    endif()
+
+    # Apply static analysis tools if enabled
+    apply_static_analysis_to_target(${target})
+endfunction()
+
+# Function to apply static analysis to targets
+function(apply_static_analysis_to_target target_name)
+    get_target_property(target_type ${target_name} TYPE)
+    if(target_type STREQUAL "INTERFACE_LIBRARY")
+        return()
+    endif()
+
+    # Clang-Tidy setup
+    if(ENABLE_CLANG_TIDY AND CLANG_TIDY_EXE)
+        # Create proper clang-tidy command with semicolon-separated arguments
+        set(CLANG_TIDY_COMMAND
+            "${CLANG_TIDY_EXE}"
+            "-header-filter=.*src/.*"
+            "--extra-arg-before=--driver-mode=cl"
+            "--extra-arg=/EHsc"
+        )
+
+        # Add error handling if requested
+        if(STATIC_ANALYSIS_AS_ERRORS)
+            list(APPEND CLANG_TIDY_COMMAND "--warnings-as-errors=*")
         endif()
 
-        # Prevent Edit-and-Continue even in Debug
-        if(POLICY CMP0141)
-            set_property(TARGET ${target} PROPERTY MSVC_DEBUG_INFORMATION_FORMAT ProgramDatabase)
-        endif()
+        set_target_properties(${target_name} PROPERTIES
+            CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+        )
+    endif()
 
+    # Cppcheck setup
+    if(ENABLE_CPPCHECK AND CPPCHECK_EXE)
+        set_target_properties(${target_name} PROPERTIES
+            CXX_CPPCHECK "${CPPCHECK_EXE};--enable=all;--inconclusive;--force;--inline-suppr;--suppress=missingIncludeSystem;--error-exitcode=$<IF:$<BOOL:${STATIC_ANALYSIS_AS_ERRORS}>,1,0>"
+        )
     endif()
 endfunction()
+
+# Global scan-build target for comprehensive analysis
+if(SCAN_BUILD_EXE)
+    add_custom_target(scan-build
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/scan-results
+        COMMAND ${SCAN_BUILD_EXE}
+        --use-analyzer=clang
+        --status-bugs
+        -o ${CMAKE_BINARY_DIR}/scan-results
+        -enable-checker deadcode
+        -enable-checker security.insecureAPI
+        -enable-checker unix.Malloc
+        -enable-checker core
+        -enable-checker cplusplus
+        -enable-checker threading
+        ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --parallel
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running comprehensive static analysis with scan-build"
+    )
+
+    # Convenience target to view results
+    if(WIN32)
+        add_custom_target(scan-build-view
+            COMMAND ${CMAKE_COMMAND} -E echo "Opening scan-build results..."
+            COMMAND cmd /c start ${CMAKE_BINARY_DIR}/scan-results/*/index.html
+            COMMENT "Opening scan-build results in browser"
+            DEPENDS scan-build
+        )
+    else()
+        add_custom_target(scan-build-view
+            COMMAND xdg-open ${CMAKE_BINARY_DIR}/scan-results/*/index.html
+            COMMENT "Opening scan-build results in browser"
+            DEPENDS scan-build
+        )
+    endif()
+endif()
+
+# Add static analysis presets
+if(ENABLE_CLANG_TIDY OR ENABLE_CPPCHECK)
+    message(STATUS "Static analysis enabled:")
+    if(ENABLE_CLANG_TIDY AND CLANG_TIDY_EXE)
+        message(STATUS "  - clang-tidy: ${CLANG_TIDY_EXE}")
+    endif()
+    if(ENABLE_CPPCHECK AND CPPCHECK_EXE)
+        message(STATUS "  - cppcheck: ${CPPCHECK_EXE}")
+    endif()
+    if(STATIC_ANALYSIS_AS_ERRORS)
+        message(STATUS "  - Treating warnings as errors")
+    endif()
+endif()
+
+if(SCAN_BUILD_EXE)
+    message(STATUS "scan-build available: Use 'cmake --build . --target scan-build' for comprehensive analysis")
+endif()
 
 function(apply_release_optimizations target)
     if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/src/client/devtools.cpp
+++ b/src/client/devtools.cpp
@@ -121,7 +121,7 @@ template <unsigned int N> void checklistManyMapped(const char *groupName, const 
             }
             else
             {
-                checkboxBitField("", i, bits);
+                checkboxBitField("Unknown", i, bits);
                 if ((i + 1) % 8 != 0)
                 {
                     auto next_desc = registry.getMapDescription(map, category, i + 1);
@@ -154,7 +154,7 @@ template <unsigned int N> void checklistManyMappedGlobal(const char *groupName, 
             }
             else
             {
-                checkboxBitField("", i, bits);
+                checkboxBitField("Unknown", i, bits);
                 if ((i + 1) % 8 != 0)
                 {
                     auto next_desc = registry.getGlobalDescription(category, i + 1);

--- a/src/library/gamestateregistry.cpp
+++ b/src/library/gamestateregistry.cpp
@@ -90,7 +90,8 @@ std::string_view GameStateRegistry::getMapDescription(MapTypes::Enum map, std::s
     {
     }
 
-    const auto &config = getMapConfig(map);
+    static const MapStateConfig empty_config{};
+    const auto &config = (map_configs_.find(map) != map_configs_.end()) ? map_configs_.at(map) : empty_config;
 
     static const std::unordered_map<std::string_view, const std::unordered_map<unsigned, std::string> MapStateConfig::*> category_map = {
         {"worldStateBits", &MapStateConfig::worldStateBits},


### PR DESCRIPTION
## Description
Fixes a mutex deadlock in the YAML parse code, and adds basic clang-tidy configurations + build targets

## Changes
- Fix double-lock in `getMapDescription()`
- Add unknown tag for empty descriptions in devtools
- Add `.clang-tidy`, cmake setup for static analysis
- Add static analysis presets

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
N/A

## Screenshots/Videos
N/A

---

<!-- Thanks for contributing! -->
