### PR TITLE
Fix Global Yaml not lazy-loading like the others

### DIFF
--- a/src/library/gamestateregistry.cpp
+++ b/src/library/gamestateregistry.cpp
@@ -170,8 +170,14 @@ const MapStateConfig &GameStateRegistry::getMapConfig(MapTypes::Enum map) const
 
 const GlobalConfig &GameStateRegistry::getGlobalConfig() const
 {
-    // NOTE: This method should NOT lock mutex or call instance()
-    // It's only called from within other methods that already hold the lock
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // load global config if not already loaded
+    if (!global_loaded_)
+    {
+        const_cast<GameStateRegistry *>(this)->loadGlobalConfig();
+    }
+
     return global_config_;
 }
 


### PR DESCRIPTION
## Description
Global yaml not being lazy-loaded like the map-specific yamls
I have no idea what I was thinking when I first wrote the registry this way

## Changes
- Fix global yaml not lazy-loading on first access
- Fix `getGlobalConfig()` not locking the registry mutex

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
Fixes #58 

## Screenshots/Videos
N/A
---

<!-- Thanks for contributing! -->
