### PR TITLE
Document and add logging to gamestateregistry

### DIFF
--- a/include/okami/igamestateregistry.h
+++ b/include/okami/igamestateregistry.h
@@ -8,31 +8,78 @@
 namespace okami
 {
 
+/**
+ * @brief Structure holding map-specific flag descriptions.
+ *
+ * Each map can define descriptions for various flag categories.
+ * Not all categories need to be present in every map's YAML file.
+ */
 struct MapStateConfig
 {
+    /// Main progression and quest flags, as well as state tracking
     std::unordered_map<unsigned, std::string> worldStateBits;
+
+    /// User-defined indices (purpose varies by map)
     std::unordered_map<unsigned, std::string> userIndices;
+
+    /// Treasure chests and collectible items
     std::unordered_map<unsigned, std::string> collectedObjects;
+
+    /// Environmental restoration flags
     std::unordered_map<unsigned, std::string> areasRestored;
+
+    /// Normal trees bloomed with Bloom technique
     std::unordered_map<unsigned, std::string> treesBloomed;
+
+    /// Cursed trees bloomed
     std::unordered_map<unsigned, std::string> cursedTreesBloomed;
+
+    /// Combat encounters cleared
     std::unordered_map<unsigned, std::string> fightsCleared;
+
+    /// NPC interaction states
     std::unordered_map<unsigned, std::string> npcs;
+
+    /// Map exploration progress
     std::unordered_map<unsigned, std::string> mapsExplored;
+
+    /// Unknown fields (for reverse engineering)
     std::unordered_map<unsigned, std::string> field_DC;
     std::unordered_map<unsigned, std::string> field_E0;
 };
 
+/**
+ * @brief Structure holding global flag descriptions.
+ *
+ * These flags apply across the entire game rather than specific maps.
+ */
 struct GlobalConfig
 {
+    /// Celestial Brush technique upgrades
     std::unordered_map<unsigned, std::string> brushUpgrades;
+
+    /// Map-independent area restoration
     std::unordered_map<unsigned, std::string> areasRestored;
+
+    /// Common states shared across maps
     std::unordered_map<unsigned, std::string> commonStates;
+
+    /// Main story progression flags
     std::unordered_map<unsigned, std::string> gameProgress;
+
+    /// Key items obtained
     std::unordered_map<unsigned, std::string> keyItemsFound;
+
+    /// Gold Dust upgrades purchased
     std::unordered_map<unsigned, std::string> goldDustsFound;
+
+    /// Animal companions found
     std::unordered_map<unsigned, std::string> animalsFound;
+
+    /// Animals fed for the first time
     std::unordered_map<unsigned, std::string> animalsFedFirstTime;
+
+    /// Global game state flags (menu states, etc.)
     std::unordered_map<unsigned, std::string> globalGameState;
 };
 
@@ -46,16 +93,53 @@ class IGameStateRegistry
   public:
     virtual ~IGameStateRegistry() = default;
 
-    // Map-specific methods
+    /**
+     * @brief Get description for a specific map state flag.
+     * @param map The map to query
+     * @param category The flag category name
+     * @param bit_index The bit index within the category
+     * @return Description or empty string if not found
+     */
     virtual std::string_view getMapDescription(MapTypes::Enum map, std::string_view category, unsigned bit_index) const = 0;
+
+    /**
+     * @brief Get full configuration for a map.
+     * @param map The map to query
+     * @return Map configuration (may be empty)
+     *
+     * The returned reference must remain valid for the lifetime of the registry.
+     */
     virtual const MapStateConfig &getMapConfig(MapTypes::Enum map) const = 0;
+
+    /**
+     * @brief Check if configuration exists for a map.
+     * @param map The map to check
+     * @return true if configuration is available
+     */
     virtual bool hasMapConfig(MapTypes::Enum map) const = 0;
 
-    // Global descriptor methods
+    /**
+     * @brief Get description for a global state flag.
+     * @param category The flag category name
+     * @param bit_index The bit index within the category
+     * @return Description or empty string if not found
+     */
     virtual std::string_view getGlobalDescription(std::string_view category, unsigned bit_index) const = 0;
+
+    /**
+     * @brief Get full global configuration.
+     * @return Global configuration
+     *
+     * The returned reference must remain valid for the lifetime of the registry.
+     */
     virtual const GlobalConfig &getGlobalConfig() const = 0;
 
-    // Reload all configs (for development)
+    /**
+     * @brief Force reload of all configurations.
+     *
+     * Optional - implementations may choose to no-op if they don't
+     * support reloading (e.g., compiled-in data).
+     */
     virtual void reload() = 0;
 };
 

--- a/src/client/logger.cpp
+++ b/src/client/logger.cpp
@@ -163,7 +163,7 @@ void Logger::setupStreamCapture()
 {
     auto captureCallback = [this](const std::string &msg, LogLevel level) { this->addLogEntry(msg, level); };
 
-    stdoutCapture_ = std::make_unique<StreamCapture>(std::cout, captureCallback, LogLevel::Info);
+    stdoutCapture_ = std::make_unique<StreamCapture>(std::cout, captureCallback, LogLevel::Debug);
     stderrCapture_ = std::make_unique<StreamCapture>(std::cerr, captureCallback, LogLevel::Error);
 }
 


### PR DESCRIPTION
## Description
Adds documentation comments to the registry and registry interface. Also adds logging at debug level to the gamestateregistry, to help further debug

## Changes
- Add doc comments to `gamestateregistry` and `igamestateregistry`
- Add logging to stout and sterr in `gamestateregistry`
- Change output captured from stout to be recorded at debug level

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
N/A

## Screenshots/Videos
N/A

---

<!-- Thanks for contributing! -->
