### PR TITLE
Improve build and development documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out/
 vcpkg_installed/
+.vs/
 CMakeUserPresets.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools-extension-pack",
+        "redhat.vscode-yaml",
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools-themes"
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ cmake --preset x64-clang-debug
 cmake --build --preset x64-clang-debug
 ```
 
-See the [README](README.md) for detailed build instructions.
+See the [Development Guide](docs/development.md) for detailed build instructions.
 
 ## Code Contributions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/):
 - **v0.x.x** = Pre-release, expect breaking changes and missing core functionality
 - **v1.0.0+** = Stable, public-sync-ready releases
 
-**While aspects of the mod may be functional or even playble in their current states, it is not recommended to run this in AP syncs yet!**
+**While aspects of the mod may be functional or even playable in their current states, it is not recommended to run this in AP syncs yet!**
 
 ## Installing
 
@@ -67,83 +67,42 @@ The reason `protontricks` is required is to place the okami-loader.exe process i
 
 ## Building From Source
 
+For development setup and detailed build instructions, see [docs/development.md](docs/development.md).
+
+### Quick Start
+```bash
+git clone --recursive https://github.com/Axertin/okami-apclient.git
+cd okami-apclient
+cmake --preset x64-clang-debug
+cmake --build --preset x64-clang-debug
+```
+
 ### Prerequisites
+- **Visual Studio 2019/2022** or Windows SDK + Clang/MSVC
+- **CMake 3.21+**, **Ninja**, **Git** with submodules support
 
-- **Visual Studio 2019/2022** (Or Windows SDK + CLang/MSVC separately)
-  - When cross-compiling from Linux, you will instead need `mingw64-gcc-c++` and `mingw64-winpthreads-static`
-- **CMake 3.21+**
-- **Ninja**
-- **Your favorite text editor** (hopefully one with CMake support to make your life easier)
+Dependencies are automatically handled through vcpkg and git submodules.
 
-When opening in Visual Studio, accept the .vsconfig prompt to install the Clang toolchain. VS may not prompt you until you re-open the project after loading it for the first time.
-
-### Dependencies
-
-- [vcpkg](https://github.com/microsoft/vcpkg)
-- [apclientpp](https://github.com/black-sliver/apclientpp)
-- [wswrap](https://github.com/black-sliver/wswrap)
-- [websocketpp](https://github.com/zaphoyd/websocketpp)
-- [imgui](https://github.com/ocornut/imgui)
-- [cpp-yaml](https://github.com/jbeder/yaml-cpp)
-
-This project uses [vcpkg](https://github.com/microsoft/vcpkg) for dependency management. Dependencies are automatically handled through the build system. Ensure you clone submodules recursively (`git clone --recursive git@github.com:Axertin/okami-apclient.git`).
-
-### Building
-
-If Ninja is already in your `PATH`, no setup is required. If you're using Visual Studio, just make sure the Ninja component is installed (it will usually be auto-detected). If Ninja is installed but not on your `PATH`, you can tell CMake where to find it using a personal `CMakeUserPresets.json`:
-
-  ```json
-  {
-    "version": 3,
-    "configurePresets": [
-      {
-        "name": "my-local-debug",
-        "inherits": "x64-clang-debug",
-        "cacheVariables": {
-          "CMAKE_MAKE_PROGRAM": "C:/path/to/ninja/ninja.exe",
-          "CMAKE_INSTALL_PREFIX": "C:/path/to/Okami"
-        }
-      }
-    ]
-  }
-  ```
-
-This example also shows how to override the install path to your own okami install directory so that cmake install targets work on your machine.
-
-To build:
-
-  ```bash
-  # Debug build
-  cmake --preset x64-clang-debug
-  cmake --build --preset x64-clang-debug
-
-  # Release build  
-  cmake --preset x64-clang-release
-  cmake --build --preset x64-clang-release
-  ```
-
-Of course, if you're cross-compiling, use the cross-compile targets.
+For first-time contributors, detailed setup instructions, and troubleshooting, see the [development guide](docs/development.md).
 
 ## Contributing
 
 Contributions are welcome! Please:
 
-1. Read [CONTRIBUTING.md](CONTRIBUTING.md)
+1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/development.md](docs/development.md)
 2. Fork the repository (or request repo access)
 3. Create a feature branch from `master`
-4. Test your changes
-5. Run `format.sh` (use Git Bash on Windows)
-   1. CI uses `clang-format` v20. You probably want to match this to ensure you're formatting the same as the CI does.
-6. Submit a pull request
+4. Test your changes and run `format.sh` (use Git Bash on Windows)
+5. Submit a pull request
 
 ## Project Structure
 
-- `src/client/`: Main mod DLL
-- `src/library/`: Library for game memory offsets, types, and structures
-- `src/loader/`: Okami Injector and DLL loader
-- `include/okami/`: Game-specific helpers, memory structures, and initializations
-- `external/`: Dependency Git submodules
-- `cmake/`: Build system utilities
+- `src/client/` - Main mod DLL
+- `src/library/` - Library for game memory offsets, types, and structures
+- `src/loader/` - Okami Injector and DLL loader
+- `include/okami/` - Game-specific helpers, memory structures, and initializations
+- `external/` - Dependency Git submodules
+- `cmake/` - Build system utilities
 
 ## Acknowledgements
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,10 +11,33 @@ This guide covers the technical details of developing okami-apclient.
 - **Ninja** build system
 - **Git** with submodules support
 
-### Visual Studio Setup
+### Recommended: VSCode Setup
+For the easiest development experience:
+
+1. **Install VS2022** with C++ development workload (for compiler toolchain)
+   - You can also install Ninja, Clang, and the Windows SDK separately, if you prefer.
+2. **Install VSCode** or VSCodium, if you prefer
+3. **Open folder** in VSCode → repo root directory
+   - VSCode will prompt to install recommended extensions - click "Install All"
+4. **CMake: Configure** → select preset (`x64-clang-debug`, or your user preset, or similar)
+5. **CMake: Build** → select target or "all"
+
+VSCode automatically hides dependency targets and provides a clean interface.
+
+### Alternative: Visual Studio
+If you prefer Visual Studio IDE...
+
 When opening the project in Visual Studio, accept the `.vsconfig` prompt to install the Clang toolchain. If it doesn't prompt you, close and reopen the project after the initial load.
 
+For more specific Visual Studio guidance, see [Visual Studio Setup](#visual-studio-setup).
+
 ## Building
+
+### Before You Start - Verification
+Run these commands to verify your setup:
+- `ninja --version` (should show "1.10+" or similar, not "command not found")
+- `git --version` 
+- `cmake --version` (should show "3.21+" or higher)
 
 ### Quick Start
 ```bash
@@ -46,6 +69,45 @@ If Ninja isn't in your PATH, create `CMakeUserPresets.json`:
   ]
 }
 ```
+
+### Visual Studio Setup (Detailed)
+
+Visual Studio's CMake integration can be tricky with dependency-heavy projects. Follow these steps for the best experience:
+
+#### Initial Setup
+1. **Open Visual Studio** (if opening from start menu, select "Continue without code")
+2. **Open the project**: File → Open → CMake... → select the repository's root `CMakeLists.txt`
+   - **Do NOT** open any `.sln` files in the `external/` folder
+3. **Accept the `.vsconfig` prompt** to install the Clang toolchain
+   - If no prompt appears, close and reopen the project after initial configuration
+
+#### Configuration and Building
+3. **Wait for initial configure** to complete (watch the Output window)
+4. **Select build preset** in the toolbar: choose `x64-clang-debug` or `x64-clang-release`
+5. **Select build target** in the dropdown next to the build button:
+   - **Main targets**: `okami-apclient`, `okami-loader`, `okami-tests`
+   - **Ignore**: All the dependency targets (imgui examples, vcpkg packages, etc.)
+   - **Tip**: The target dropdown will be very long due to dependencies - scroll to find your targets
+
+#### Target Selection Tips
+- **Default startup**: The first target alphabetically will be selected initially
+- **Main targets to use**:
+  - `okami-loader` - The injector executable
+  - `okami-apclient` - The main mod DLL
+  - `okami-tests` - Unit tests
+- **Avoid**: Any targets with names like `example_*`, `*_test`, or vcpkg package names
+
+#### Building
+- **Single target**: Select target → press F7 or click Build
+- **All targets**: Use the command line instead: `cmake --build --preset x64-clang-debug`
+- **Clean build**: Build → Clean All, then rebuild
+
+#### Troubleshooting
+- **"Target not found" errors**: Make sure you selected the root `CMakeLists.txt`, not a subdirectory
+- **Clang not working**: Ensure the Clang toolchain is installed via the VS Installer
+- **Too many targets**: This is normal - dependencies expose many targets that can't be hidden in VS
+- **Git submodules missing**: Run `git submodule update --init --recursive`
+- **vcpkg errors**: Delete `out/` folder and reconfigure
 
 ## Code Style & Formatting
 


### PR DESCRIPTION
## Description
Improves documentation relating to developers, including environment setup, toolchain installation, and CMake usage.

## Changes
- Added .vs/ to gitignore
- Added step-by-step setup for VSCode and VS
- Pared down README to focus more on users and direct to development.md for in-depth developer stuff
- Added extensions.json to prompt for required vscode extensions on first open

## Testing
<!-- How did you test this? -->
N/A, docs change

## Related Issues
N/A

## Screenshots/Videos
N/A

---

<!-- Thanks for contributing! -->
