### PR TITLE
Prereqs for AP integration, all shop hooks

### DIFF
--- a/include/okami/data/itemtype.hpp
+++ b/include/okami/data/itemtype.hpp
@@ -264,7 +264,15 @@ enum Enum
     GaleShrineMap,
     Whopper,
     CutlassFish,
-    NUM_ITEM_TYPES
+    NUM_ITEM_TYPES,
+
+    ArchipelagoTestItem1 = Unused_78,
+    ArchipelagoTestItem2 = Chestnut,
+    ArchipelagoTestItem3 = Unused_82,
+    ArchipelagoTestItem4 = Unused_A2,
+    ArchipelagoTestItem5 = Unused_A8,
+    ArchipelagoTestItem6 = Unused_AC,
+    ArchipelagoTestItem7 = Unused_AF,
 };
 
 const char *GetName(unsigned value);

--- a/include/okami/data/structs.hpp
+++ b/include/okami/data/structs.hpp
@@ -373,6 +373,45 @@ struct cItemShop : cShopBase
     int32_t field_CC;
 };
 
+struct cKibaShop : cShopBase
+{
+    ItemShopStock *itemStockList;
+    uint32_t numShopItems;
+    int32_t field_A4;
+    float field_A8;
+    float field_AC;
+    float field_B0;
+    char field_B4;
+    char field_B5;
+    char field_B6;
+    char field_B7;
+    int32_t inputController;
+    int32_t lastPressedController;
+};
+
+struct SkillShopStock
+{
+    uint16_t skillId;
+    uint16_t field_2;
+    int32_t cost;
+    int32_t field_8;
+    int32_t field_C;
+};
+
+struct cSkillShop : cShopBase
+{
+    SkillShopStock *skillList;
+    int32_t field_A0;
+    int32_t purchasedSkillId;
+    float field_A8;
+    float field_AC;
+    float field_B0;
+    uint8_t numSkillSlots;
+    uint8_t field_B5[3];
+    int32_t inputController;
+    int32_t lastPressedController;
+};
+
 // Don't know about name, relationships, or size
 // This is pl00 I think?
 struct cAmmyModel
@@ -385,5 +424,14 @@ struct cAmmyModel
     wk::math::cVec *pSpawnPosition;
     wk::math::cVec *pPosition;
     // lots more below but we don't care
+};
+
+struct ItemParam
+{
+    uint16_t maxCount;
+    int16_t value;
+    uint32_t flags;
+    uint8_t category;
+    uint8_t padding[3];
 };
 } // namespace okami

--- a/include/okami/data/structs.hpp
+++ b/include/okami/data/structs.hpp
@@ -374,9 +374,16 @@ struct cItemShop : cShopBase
 };
 
 // Don't know about name, relationships, or size
+// This is pl00 I think?
 struct cAmmyModel
 {
-    int32_t whatever[42];
+    void *vtable;
+    int32_t whatever[14];
+    wk::math::cVec savedPos;
+    wk::math::cMatrix mtx;
+    int32_t field_90[4];
+    wk::math::cVec *pSpawnPosition;
     wk::math::cVec *pPosition;
+    // lots more below but we don't care
 };
 } // namespace okami

--- a/include/okami/data/structs.hpp
+++ b/include/okami/data/structs.hpp
@@ -321,7 +321,10 @@ struct cShopBase : public DummyVirtTable
     cObjGui gui;
     ShopInventory *inventory;
     ShopInventory *inventorySorted;
+
+    // Size allocated is only for 50 slots max, for all shop types
     ShopSlotData *shopSlots;
+
     const char *pszShopNpcImgFile;
     void *pShopRscPkg;
     void *pIconsRsc;

--- a/include/okami/data/structs.hpp
+++ b/include/okami/data/structs.hpp
@@ -338,8 +338,8 @@ struct cShopBase : public DummyVirtTable
     int16_t purchaseQuantity;
     uint8_t numSlots;
     uint8_t numVisibleSlots;
-    char scrollOffset;
-    char visualSelectIndex;
+    uint8_t scrollOffset;
+    uint8_t visualSelectIndex;
     char field_84;
     char field_85;
     char field_86;

--- a/include/okami/memorymap.hpp
+++ b/include/okami/memorymap.hpp
@@ -44,7 +44,6 @@ extern MemoryAccessor<int16_t> MoneyUpgradeBar;
 extern MemoryAccessor<int16_t> InkUpgradeBar;
 
 // Other important things
-extern MemoryAccessor<uint8_t> LoadingZoneTrigger;
 extern MemoryAccessor<float> CameraFOV;
 
 extern void *MaybeAmmyObject;

--- a/src/client/archipelagosocket.cpp
+++ b/src/client/archipelagosocket.cpp
@@ -10,6 +10,7 @@
 #pragma warning(pop)
 
 #include <filesystem>
+#include <string>
 
 // File-local constants
 static const std::string CERT_STORE = "mods/apclient/cacert.pem";

--- a/src/client/devdatafinder.cpp
+++ b/src/client/devdatafinder.cpp
@@ -304,7 +304,7 @@ void comparePreviousCollection()
 
     for (unsigned i = 0; i < 56; i++)
     {
-        std::string name = std::string("WorldStateData::unk11[") + std::to_string(i) + "]";
+        std::string name = "WorldStateData::unk11[" + std::to_string(i) + "]";
         compareInt(name.c_str(), old.world.unk11[i], current.world.unk11[i]);
     }
 
@@ -312,7 +312,7 @@ void comparePreviousCollection()
 
     for (unsigned i = 0; i < 3; i++)
     {
-        std::string name = std::string("WorldStateData::unk15[") + std::to_string(i) + "]";
+        std::string name = "WorldStateData::unk15[" + std::to_string(i) + "]";
         compareInt(name.c_str(), old.world.unk15[i], current.world.unk15[i]);
     }
 
@@ -320,7 +320,7 @@ void comparePreviousCollection()
 
     for (unsigned i = 0; i < 4; i++)
     {
-        std::string name = std::string("WorldStateData::unk17[") + std::to_string(i) + "]";
+        std::string name = "WorldStateData::unk17[" + std::to_string(i) + "]";
         compareInt(name.c_str(), old.world.unk17[i], current.world.unk17[i]);
     }
 
@@ -330,13 +330,13 @@ void comparePreviousCollection()
 
     for (unsigned i = 0; i < 194; i++)
     {
-        std::string name = std::string("WorldStateData::unk22[") + std::to_string(i) + "]";
+        std::string name = "WorldStateData::unk22[" + std::to_string(i) + "]";
         compareInt(name.c_str(), old.world.unk22[i], current.world.unk22[i]);
     }
 
     for (unsigned i = 0; i < 7; i++)
     {
-        std::string name = std::string("WorldStateData::unk24[") + std::to_string(i) + "]";
+        std::string name = "WorldStateData::unk24[" + std::to_string(i) + "]";
         compareInt(name.c_str(), old.world.unk24[i], current.world.unk24[i]);
     }
 }
@@ -370,7 +370,7 @@ void comparePreviousMapData()
             if (mapConfig.userIndices.contains(j))
                 continue;
 
-            std::string name = mapNamePrefix + std::string("MapState::user[") + std::to_string(j) + "]";
+            std::string name = mapNamePrefix + "MapState::user[" + std::to_string(j) + "]";
             compareInt(name.c_str(), old[i].user[j], current[i].user[j]);
         }
 

--- a/src/client/devtools.cpp
+++ b/src/client/devtools.cpp
@@ -100,8 +100,10 @@ void drawStat(const char *name, int type, void *pCurrent)
 
 template <unsigned int N> void checkboxBitField(const char *label, unsigned idx, okami::BitField<N> &bits)
 {
+    ImGui::PushID(idx);
     ImGui::CheckboxFlags(label, bits.GetIdxPtr(idx), bits.GetIdxMask(idx));
     ImGui::SetItemTooltip("%d (0x%X)", idx, idx);
+    ImGui::PopID();
 }
 
 template <unsigned int N> void checklistManyMapped(const char *groupName, const char *category, okami::MapTypes::Enum map, okami::BitField<N> &bits)
@@ -814,7 +816,7 @@ void DevTools::draw(int OuterWidth, int OuterHeight, float UIScale)
         {
             okami::ExteriorMapID.set(MapID);
             okami::CurrentMapID.set(MapID);
-            okami::LoadingZoneTrigger.set(0x2);
+            okami::GlobalGameStateFlags->Set(6);
         }
 
         checklistManyMappedGlobal("Global Event Bits", "commonStates", okami::AmmyCollections->world.mapStateBits[0]);

--- a/src/client/devtools.cpp
+++ b/src/client/devtools.cpp
@@ -791,7 +791,7 @@ void DevTools::draw(int OuterWidth, int OuterHeight, float UIScale)
         {
             for (int i = 0; i < 64; i++)
             {
-                std::string name = std::string("BrushUnk") + std::to_string(i);
+                std::string name = "BrushUnk" + std::to_string(i);
                 drawStat(name.c_str(), ImGuiDataType_U8, &okami::AmmyBrushUpgrades->data()[i]);
             }
         }

--- a/src/client/gamehooks.cpp
+++ b/src/client/gamehooks.cpp
@@ -1,6 +1,7 @@
 #include "gamehooks.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include "aplocationmonitor.h"
 #include "archipelagosocket.h"
@@ -87,7 +88,6 @@ bool __fastcall GameHooks::onBrushEdit(void *MaybeInventoryStruct, int BitIndex,
 
 static int64_t(__fastcall *oGetShopVariation)(void *, uint32_t shopNum, char **pszShopTextureName);
 static const void *(__fastcall *oGetShopMetadata)(void *, uint32_t shopNum, uint32_t *pNumEvents, char **pszShopTextureName);
-static const void *(__fastcall *oLoadRsc)(void *pRscPackage, const char *pszType, uint32_t nIdx);
 static okami::ItemShopStock *(__fastcall *ocKibaShop__GetShopStockList)(void *, uint32_t *numItems);
 
 static int64_t __fastcall onGetShopVariation(void *pUnk, uint32_t shopNum, char **pszShopTextureName)
@@ -99,10 +99,12 @@ static int64_t __fastcall onGetShopVariation(void *pUnk, uint32_t shopNum, char 
     return 0;
 }
 
+static const void *(__fastcall *oLoadRsc)(void *pRscPackage, const char *pszType, uint32_t nIdx);
 static const void *__fastcall onLoadRsc(void *pRscPackage, const char *pszType, uint32_t nIdx)
 {
     if (strcmp(pszType, "ISL") == 0)
     {
+        // nIdx is the shop number for the map, only 1 for Seian Fish Shop
         const void *pResult = GetCurrentItemShopData(nIdx);
         if (pResult == nullptr)
         {
@@ -138,8 +140,13 @@ template <class T> void CreateHook(uintptr_t base, uintptr_t offset, T *pDetour,
 {
     MH_CreateHook(reinterpret_cast<void *>(base + offset), reinterpret_cast<LPVOID>(pDetour), reinterpret_cast<LPVOID *>(ppOriginal));
 }
+template <class T> void CreateHook(uintptr_t base, uintptr_t offset, T *pDetour)
+{
+    MH_CreateHook(reinterpret_cast<void *>(base + offset), reinterpret_cast<LPVOID>(pDetour), nullptr);
+}
 
 static void *(__fastcall *oLoadRscIdx)(void *pPkg, uint32_t idx);
+
 static hx::Texture *(__fastcall *oCItemShop_GetItemIcon)(okami::cItemShop *pShop, int item);
 hx::Texture *__fastcall GetItemIcon(okami::cItemShop *pShop, int item)
 {
@@ -159,7 +166,7 @@ void *__fastcall onLoadResourcePackageAsync(void *pFilesystem, const char *pszFi
                                             int32_t a8)
 {
     // Intercept item shop icons
-    if (pszFilename && strcmp(pszFilename, "id/ItemShopBuyIcon.dat") == 0)
+    if (pszFilename && std::strcmp(pszFilename, "id/ItemShopBuyIcon.dat") == 0)
     {
         pszFilename = "archipelago/ItemPackage.dat";
     }
@@ -197,6 +204,8 @@ void __fastcall onLoadCore20MSD(void *pMsgStruct)
     if (!msdInitialized)
     {
         Core20MSD.ReadMSD(*ppCore20MSD);
+
+        // Vanilla items with missing strings
         Core20MSD.OverrideString(okami::ItemTypes::HourglassOrb + ItemStrBaseID, "Hourglass Orb");
         Core20MSD.OverrideString(okami::ItemTypes::Yen10 + ItemStrBaseID, "10 Yen");
         Core20MSD.OverrideString(okami::ItemTypes::Yen50 + ItemStrBaseID, "50 Yen");
@@ -205,6 +214,7 @@ void __fastcall onLoadCore20MSD(void *pMsgStruct)
         Core20MSD.OverrideString(okami::ItemTypes::Yen500 + ItemStrBaseID, "500 Yen");
         Core20MSD.OverrideString(okami::ItemTypes::Praise + ItemStrBaseID, "Praise");
 
+        // Test item string
         TestItemTextID = Core20MSD.AddString("Heinermann's Morph Ball");
 
         msdInitialized = true;
@@ -212,39 +222,296 @@ void __fastcall onLoadCore20MSD(void *pMsgStruct)
     *ppCore20MSD = Core20MSD.GetData();
 }
 
-uint16_t __fastcall GetItemNameStrId(uint16_t item)
-{
-    if (item == okami::ItemTypes::Unused_52)
-    {
-        return TestItemTextID;
-    }
-    return item + 294;
-}
+static std::unordered_set<uint16_t> ArchipelagoItemTypes = {
+    okami::ItemTypes::ArchipelagoTestItem1, okami::ItemTypes::ArchipelagoTestItem2, okami::ItemTypes::ArchipelagoTestItem3,
+    okami::ItemTypes::ArchipelagoTestItem4, okami::ItemTypes::ArchipelagoTestItem5, okami::ItemTypes::ArchipelagoTestItem6,
+    okami::ItemTypes::ArchipelagoTestItem7,
+};
 
 constexpr uint8_t MaxVisibleSlots = 4;
-static uint32_t(__fastcall *oCItemShop_UpdatePurchaseList)(okami::cItemShop *pItemShop);
-uint32_t __fastcall onCItemShop_UpdatePurchaseList(okami::cItemShop *pItemShop)
-{
-    // Just rewrite it because why not, I have the POWER
-    pItemShop->numSlots = pItemShop->numItemSlots;
-    pItemShop->numVisibleSlots = std::min(pItemShop->numSlots, MaxVisibleSlots);
 
-    for (uint32_t i = 0; i < pItemShop->numSlots; i++)
+/*
+TODO:
+  Item descriptions are loaded from id/iditemshop.idd -> bin TBL -> PAC -> MSD.
+  Index in the UI is `0x2000 + itemId`, just `0 + itemId` in MSD file.
+
+  However we can modify the description by modifying the GUI directly,
+  in a post-hook on 0x43C6F0 void cItemShop::ShopInteractUpdate(cItemShop*),
+  using 0x1B6CA0 void __fastcall _SetUIStrId(cObjGui *gui, unsigned __int8 ctrlId, __int16 strId)
+
+  // 11 is the control index for the description textbox
+  _SetUIStrId(pShop->gui, 11, itemDescId);
+
+  Vanilla items that have missing descriptions:
+  - Ruins Key
+  - Oddly Shaped Turnip
+  - Hourglass Orb
+  - 10/50/100/150/500 Yen
+  - Praise
+  - Vista of the Gods
+  - Spirit Globe S + Ink Pot
+*/
+uint32_t __fastcall onCItemShop_UpdatePurchaseList(okami::cItemShop *pShop)
+{
+    // Rewrite - don't call original
+    pShop->numSlots = pShop->numItemSlots;
+    pShop->numVisibleSlots = std::min(pShop->numSlots, MaxVisibleSlots);
+
+    for (uint32_t i = 0; i < pShop->numSlots; i++)
     {
-        int32_t itemType = pItemShop->itemStockList[i].itemType;
-        pItemShop->shopSlots[i].itemType = itemType;
+        int32_t itemType = pShop->itemStockList[i].itemType;
+        pShop->shopSlots[i].itemType = itemType;
 
         // TODO: This is where we choose a different icon and text for the same item type
-        pItemShop->shopSlots[i].pIcon = GetItemIcon(pItemShop, itemType);
-        pItemShop->shopSlots[i].itemNameStrId = GetItemNameStrId(itemType);
+        if (ArchipelagoItemTypes.contains(itemType))
+        {
+            pShop->shopSlots[i].pIcon = GetItemIcon(pShop, okami::ItemTypes::ArchipelagoTestItem1);
+            pShop->shopSlots[i].itemNameStrId = TestItemTextID;
+        }
+        else
+        {
+            pShop->shopSlots[i].pIcon = GetItemIcon(pShop, itemType);
+            pShop->shopSlots[i].itemNameStrId = itemType + 294;
+        }
 
         // Decide the max count for purchases: 0 / #
-        pItemShop->shopSlots[i].maxCount = 1;
+        pShop->shopSlots[i].maxCount = 1;
 
-        pItemShop->shopSlots[i].currentCount = okami::AmmyCollections->inventory[itemType];
-        pItemShop->shopSlots[i].itemCost = pItemShop->itemStockList[i].cost;
+        pShop->shopSlots[i].currentCount = okami::AmmyCollections->inventory[itemType];
+        pShop->shopSlots[i].itemCost = pShop->itemStockList[i].cost;
     }
-    return pItemShop->numItemSlots;
+    return pShop->numItemSlots;
+}
+
+// Brings up the confirmation dialog for a purchase
+static void(__fastcall *oCItemShop_PurchaseItem)(okami::cItemShop *pShop);
+static void __fastcall onCItemShop_PurchaseItem(okami::cItemShop *pShop)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+    // int32_t variation = pShop->shopStockVariation;
+
+    // The index of the item in the shop
+    int selIdx = pShop->scrollOffset + pShop->visualSelectIndex;
+
+    // Item type, do something different if it's "the" Archipelago Item
+    int itemType = pShop->shopSlots[selIdx].itemType;
+
+    // TODO replace/detect actual purchase
+    if (ArchipelagoItemTypes.contains(itemType))
+    {
+        // Wipe the item from inventory to detect whether it gets purchased or not
+        okami::AmmyCollections->inventory[itemType] = 0;
+
+        oCItemShop_PurchaseItem(pShop);
+
+        if (okami::AmmyCollections->inventory[itemType] != 0)
+        {
+            // TODO: TRIGGER ARCHIPELAGO PURCHASE OF SHOP SLOT HERE (send send send!)
+            // TODO: Also mark a flag in save file somewhere to note that this has been purchased
+            // Get AP id from mapID, variation, and selIdx
+
+            okami::AmmyCollections->inventory[itemType] = 0;
+        }
+    }
+    else
+    {
+        oCItemShop_PurchaseItem(pShop);
+    }
+}
+
+static bool(__fastcall *oCItemShop_IsSoldOut)(okami::cItemShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCItemShop_IsSoldOut(okami::cItemShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+    // int32_t variation = pShop->shopStockVariation;
+
+    // TODO: return true when AP item is marked as obtained (received)
+
+    return oCItemShop_IsSoldOut(pShop, shopIdx);
+}
+
+static bool(__fastcall *oCItemShop_IsPurchasable)(okami::cItemShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCItemShop_IsPurchasable(okami::cItemShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+    // int32_t variation = pShop->shopStockVariation;
+
+    // TODO: return false when AP item is marked as obtained (received)
+
+    // false = greyed
+    return oCItemShop_IsPurchasable(pShop, shopIdx);
+}
+
+uint32_t __fastcall onCKibaShop_UpdatePurchaseList(okami::cKibaShop *pShop)
+{
+    // Rewrite - don't call original
+    pShop->numSlots = pShop->numShopItems;
+    pShop->numVisibleSlots = std::min(pShop->numSlots, MaxVisibleSlots);
+
+    for (uint32_t i = 0; i < pShop->numSlots; i++)
+    {
+        int32_t itemType = pShop->itemStockList[i].itemType;
+        pShop->shopSlots[i].itemType = itemType;
+
+        // TODO: This is where we choose a different icon and text for the same item type
+        if (ArchipelagoItemTypes.contains(itemType))
+        {
+            // TODO FIXME need to load the big item icon list elsewhere
+            // pShop->shopSlots[i].pIcon = GetItemIcon(pShop, okami::ItemTypes::ArchipelagoTestItem1);
+            pShop->shopSlots[i].pIcon = nullptr;
+            pShop->shopSlots[i].itemNameStrId = TestItemTextID;
+        }
+        else
+        {
+            // TODO FIXME need to load the big item icon list elsewhere
+            // pShop->shopSlots[i].pIcon = GetItemIcon(pShop, itemType);
+            pShop->shopSlots[i].pIcon = nullptr;
+            pShop->shopSlots[i].itemNameStrId = itemType + 294;
+        }
+
+        // Decide the max count for purchases: 0 / #
+        pShop->shopSlots[i].maxCount = 1;
+
+        pShop->shopSlots[i].currentCount = okami::AmmyCollections->inventory[itemType];
+        pShop->shopSlots[i].itemCost = pShop->itemStockList[i].cost;
+    }
+    return pShop->numShopItems;
+}
+
+// Brings up the confirmation dialog for a purchase
+static void(__fastcall *oCKibaShop_PurchaseItem)(okami::cKibaShop *pShop);
+static void __fastcall onCKibaShop_PurchaseItem(okami::cKibaShop *pShop)
+{
+    // Use this to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // The index of the item in the shop
+    int selIdx = pShop->scrollOffset + pShop->visualSelectIndex;
+
+    // Item type, do something different if it's "the" Archipelago Item
+    int itemType = pShop->shopSlots[selIdx].itemType;
+
+    // TODO replace/detect actual purchase
+    if (ArchipelagoItemTypes.contains(itemType))
+    {
+        // Wipe the item from inventory to detect whether it gets purchased or not
+        okami::AmmyCollections->inventory[itemType] = 0;
+
+        oCKibaShop_PurchaseItem(pShop);
+
+        if (okami::AmmyCollections->inventory[itemType] != 0)
+        {
+            // TODO: TRIGGER ARCHIPELAGO PURCHASE OF SHOP SLOT HERE (send send send!)
+            // TODO: Also mark a flag in save file somewhere to note that this has been purchased
+            // Get AP id from mapID, variation, and selIdx
+
+            okami::AmmyCollections->inventory[itemType] = 0;
+        }
+    }
+    else
+    {
+        oCKibaShop_PurchaseItem(pShop);
+    }
+}
+
+static bool(__fastcall *oCKibaShop_IsSoldOut)(okami::cKibaShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCKibaShop_IsSoldOut(okami::cKibaShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // TODO: return true when AP item is marked as obtained (received)
+
+    return oCKibaShop_IsSoldOut(pShop, shopIdx);
+}
+
+static bool(__fastcall *oCKibaShop_IsPurchasable)(okami::cKibaShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCKibaShop_IsPurchasable(okami::cKibaShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // TODO: return false when AP item is marked as obtained (received)
+
+    // false = greyed
+    return oCKibaShop_IsPurchasable(pShop, shopIdx);
+}
+
+uint32_t __fastcall onCSkillShop_UpdatePurchaseList(okami::cSkillShop *pShop)
+{
+    // Rewrite - don't call original
+    pShop->numSlots = pShop->numSkillSlots;
+    pShop->numVisibleSlots = std::min(pShop->numSlots, MaxVisibleSlots);
+
+    for (uint32_t i = 0; i < pShop->numSlots; i++)
+    {
+        int32_t skillType = pShop->skillList[i].skillId;
+
+        // TODO: This is where we choose a different icon and text for the same item type
+        pShop->shopSlots[i].itemCost = pShop->skillList[i].cost;
+        pShop->shopSlots[i].pIcon = nullptr;
+        // 0x2000 is a context specific offset
+        // anything 0x2000 + n here is found in id/idskillshop.idd -> bin TBL -> PAC -> MSD
+        // but that also means we can just use the existing global MSD modifications with a low ID
+        pShop->shopSlots[i].itemNameStrId = skillType + 0x2000;
+    }
+    return pShop->numSkillSlots;
+}
+
+// Brings up the confirmation dialog for a purchase
+static void(__fastcall *oCSkillShop_PurchaseSkill)(okami::cSkillShop *pShop);
+static void __fastcall onCSkillShop_PurchaseSkill(okami::cSkillShop *pShop)
+{
+    // Use this to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // The index of the item in the shop
+    // int selIdx = pShop->scrollOffset + pShop->visualSelectIndex;
+
+    // Item type, do something different if it's "the" Archipelago Item
+    // int skillType = pShop->skillList[selIdx].skillId;
+
+    // TODO replace/detect actual purchase
+
+    oCSkillShop_PurchaseSkill(pShop);
+}
+
+static bool(__fastcall *oCSkillShop_IsSkillNotLearned)(okami::cSkillShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCSkillShop_IsSkillNotLearned(okami::cSkillShop *pShop, uint32_t shopIdx)
+{
+    // Determines how the entry gets drawn
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // TODO: return false when AP item is marked as obtained (received)
+
+    return oCSkillShop_IsSkillNotLearned(pShop, shopIdx);
+}
+
+static bool(__fastcall *oCSkillShop_IsSoldOut)(okami::cSkillShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCSkillShop_IsSoldOut(okami::cSkillShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // TODO: return true when AP item is marked as obtained (received)
+
+    return oCSkillShop_IsSoldOut(pShop, shopIdx);
+}
+
+static bool(__fastcall *oCSkillShop_IsPurchasable)(okami::cSkillShop *pShop, uint32_t shopIdx);
+static bool __fastcall onCSkillShop_IsPurchasable(okami::cSkillShop *pShop, uint32_t shopIdx)
+{
+    // Use these to get the Archipelago shop ID
+    // uint16_t mapID = okami::ExteriorMapID.get();
+
+    // TODO: return false when AP item is marked as obtained (received)
+
+    // false = greyed
+    return oCSkillShop_IsPurchasable(pShop, shopIdx);
 }
 
 /**
@@ -268,12 +535,28 @@ void GameHooks::setup()
 
     CreateHook(okami::MainBase, 0x4420C0, &onGetShopVariation, &oGetShopVariation);
     CreateHook(okami::MainBase, 0x1B1770, &onLoadRsc, &oLoadRsc);
-    CreateHook(okami::MainBase, 0x43F5A0, &onCKibaShop__GetShopStockList, &ocKibaShop__GetShopStockList);
     CreateHook(okami::MainBase, 0x1AFC90, &onLoadResourcePackageAsync, &oLoadResourcePackageAsync);
     CreateHook(okami::MainBase, 0x1412B0, &onGXTextureManager_GetNumEntries, &oGXTextureManager_GetNumEntries);
     CreateHook(okami::MainBase, 0x1C9510, &onLoadCore20MSD, &oLoadCore20MSD);
 
-    CreateHook(okami::MainBase, 0x43E250, &onCItemShop_UpdatePurchaseList, &oCItemShop_UpdatePurchaseList);
+    // Item shop
+    CreateHook(okami::MainBase, 0x43E250, &onCItemShop_UpdatePurchaseList);
+    CreateHook(okami::MainBase, 0x43CA30, &onCItemShop_PurchaseItem, &oCItemShop_PurchaseItem);
+    CreateHook(okami::MainBase, 0x43BAE0, &onCItemShop_IsSoldOut, &oCItemShop_IsSoldOut);
+    CreateHook(okami::MainBase, 0x43B6A0, &onCItemShop_IsPurchasable, &oCItemShop_IsPurchasable);
+
+    // Demon fang shop
+    CreateHook(okami::MainBase, 0x43F5A0, &onCKibaShop__GetShopStockList, &ocKibaShop__GetShopStockList);
+    CreateHook(okami::MainBase, 0x440380, &onCKibaShop_UpdatePurchaseList);
+    CreateHook(okami::MainBase, 0x43FD30, &onCKibaShop_PurchaseItem, &oCKibaShop_PurchaseItem);
+    CreateHook(okami::MainBase, 0x43F440, &onCKibaShop_IsSoldOut, &oCKibaShop_IsSoldOut);
+    CreateHook(okami::MainBase, 0x43F2F0, &onCKibaShop_IsPurchasable, &oCKibaShop_IsPurchasable);
+
+    // Skill shop
+    CreateHook(okami::MainBase, 0x4431B0, &onCSkillShop_UpdatePurchaseList);
+    CreateHook(okami::MainBase, 0x442570, &onCSkillShop_IsSkillNotLearned, &oCSkillShop_IsSkillNotLearned);
+    CreateHook(okami::MainBase, 0x4423C0, &onCSkillShop_IsSoldOut, &oCSkillShop_IsSoldOut);
+    CreateHook(okami::MainBase, 0x4421C0, &onCSkillShop_IsPurchasable, &oCSkillShop_IsPurchasable);
 
     oCItemShop_GetItemIcon = reinterpret_cast<decltype(oCItemShop_GetItemIcon)>(okami::MainBase + 0x43BDA0);
     oGetShopMetadata = reinterpret_cast<decltype(oGetShopMetadata)>(okami::MainBase + 0x441E40);

--- a/src/client/shop.h
+++ b/src/client/shop.h
@@ -7,6 +7,10 @@
 #include "okami/filebuffer.h"
 #include "okami/shopdata.h"
 
+// Hardcoded max shop stock size unless we want to hook the memory allocation for it
+// It always allocates this much regardless of how much stock was loaded.
+constexpr size_t MaxShopStockSize = 50;
+
 /***
  * Simple shop data definition (no variations as in vanilla).
  * In order to work, shop variations need to also be eliminated.

--- a/src/client/shopdef.cpp
+++ b/src/client/shopdef.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdint>
+#include <iostream>
 
 #include "shop.h"
 
@@ -40,13 +41,27 @@ const std::uint8_t *ShopDefinition::GetData()
 
 void ShopDefinition::SetStock(const std::vector<okami::ItemShopStock> &stock)
 {
-    this->itemStock = stock;
+    if (stock.size() < MaxShopStockSize)
+    {
+        this->itemStock = stock;
+    }
+    else
+    {
+        std::cerr << "Max stock size in SetStock exceeded" << std::endl;
+    }
     this->dirty = true;
 }
 
 void ShopDefinition::AddItem(okami::ItemTypes::Enum item, std::int32_t cost)
 {
-    this->itemStock.emplace_back(okami::ItemShopStock{item, cost});
+    if (this->itemStock.size() < MaxShopStockSize)
+    {
+        this->itemStock.emplace_back(okami::ItemShopStock{item, cost});
+    }
+    else
+    {
+        std::cerr << "Max stock size in AddItem exceeded" << std::endl;
+    }
     this->dirty = true;
 }
 

--- a/src/client/shops.cpp
+++ b/src/client/shops.cpp
@@ -55,6 +55,12 @@ void InitializeShopData()
 {
     // TODO update shops with AP information here
     KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem1, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem2, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem3, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem4, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem5, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem6, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem7, 2);
     KamikiShop.AddItem(okami::ItemTypes::Praise, 100);
     for (uint32_t i = 1; i < 10; i++)
     {

--- a/src/client/shops.cpp
+++ b/src/client/shops.cpp
@@ -54,7 +54,7 @@ Missing name and desc:
 void InitializeShopData()
 {
     // TODO update shops with AP information here
-    KamikiShop.AddItem(okami::ItemTypes::Unused_52, 2);
+    KamikiShop.AddItem(okami::ItemTypes::ArchipelagoTestItem1, 2);
     KamikiShop.AddItem(okami::ItemTypes::Praise, 100);
     for (uint32_t i = 1; i < 10; i++)
     {

--- a/src/library/dataverify.cpp
+++ b/src/library/dataverify.cpp
@@ -116,3 +116,4 @@ static_assert(sizeof(cObjGui) == 0x30);
 static_assert(sizeof(cShopBase) == 0x98);
 static_assert(sizeof(cItemShop) == 0xD0);
 static_assert(sizeof(ShopInventory) == 8);
+static_assert(sizeof(ItemParam) == 0xC);

--- a/src/library/memorymap.cpp
+++ b/src/library/memorymap.cpp
@@ -28,6 +28,7 @@ MemoryAccessor<CollectionData> AmmyCollections;
 MemoryAccessor<TrackerData> AmmyTracker;
 MemoryAccessor<std::array<MapState, MapTypes::NUM_MAP_TYPES>> MapData;
 MemoryAccessor<std::array<BitField<512>, MapTypes::NUM_MAP_TYPES>> DialogBits;
+static MemoryAccessor<std::array<ItemParam, ItemTypes::NUM_ITEM_TYPES>> ItemParams;
 
 MemoryAccessor<BitField<86>> GlobalGameStateFlags;
 
@@ -121,6 +122,10 @@ void initVariables()
     AmmyUsableBrushes.bind(okami::MainBase + 0x890A30);
     AmmyObtainedBrushes.bind(okami::MainBase + 0x890A38);
     AmmyBrushUpgrades.bind(okami::MainBase + 0x8909C0 + 0x80);
+    ItemParams.bind(okami::MainBase + 0x7AB220);
+
+    // TODO test each value up to and including 7
+    ItemParams->at(ItemTypes::ArchipelagoTestItem1).category = 0;
 }
 
 /**

--- a/src/library/memorymap.cpp
+++ b/src/library/memorymap.cpp
@@ -125,7 +125,21 @@ void initVariables()
     ItemParams.bind(okami::MainBase + 0x7AB220);
 
     // TODO test each value up to and including 7
-    ItemParams->at(ItemTypes::ArchipelagoTestItem1).category = 0;
+    // 0 = grey
+    // 1 = peach - pickups, food
+    // 2 = peach - consumable items, KT
+    // 3 = cyan
+    // 4 = red - divine instrument
+    // 5 = purple - treasure
+    // 6 = cyan - fish
+    // 7 = yellow - key item, travel guide, map, stray bead
+    ItemParams->at(ItemTypes::ArchipelagoTestItem1).category = 1;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem2).category = 2;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem3).category = 3;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem4).category = 4;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem5).category = 5;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem6).category = 6;
+    ItemParams->at(ItemTypes::ArchipelagoTestItem7).category = 7;
 }
 
 /**

--- a/src/library/memorymap.cpp
+++ b/src/library/memorymap.cpp
@@ -46,7 +46,6 @@ MemoryAccessor<int16_t> MoneyUpgradeBar;
 MemoryAccessor<int16_t> InkUpgradeBar;
 
 // Other important things
-MemoryAccessor<uint8_t> LoadingZoneTrigger;
 MemoryAccessor<float> CameraFOV;
 
 void *MaybeAmmyObject;
@@ -113,7 +112,6 @@ void initVariables()
     VestigialMapID1.bind(okami::MainBase + 0xB4F0B4);
     VestigialMapID2.bind(okami::MainBase + 0xB6B246);
 
-    LoadingZoneTrigger.bind(okami::MainBase + 0xB6B2AF);
     CameraFOV.bind(okami::MainBase + 0xB663B0);
 
     MaybeAmmyObject = reinterpret_cast<void *>(okami::MainBase + 0xB6B2D0);

--- a/src/library/resource.cpp
+++ b/src/library/resource.cpp
@@ -538,7 +538,7 @@ void RecompileItemGraphics()
     for (unsigned i = 0; i < ItemTypes::NUM_ITEM_TYPES; i++)
     {
         // FIXME: this is temporary until suspend process hooks are fixed
-        if (i == okami::ItemTypes::Unused_52)
+        if (i == okami::ItemTypes::ArchipelagoTestItem1)
         {
             std::optional<data_t> apIcon = LoadAPIcon();
             if (apIcon)


### PR DESCRIPTION
## Description
Creates tons of shop hooks as prereqs for AP integration.

## Changes
- Hooks for all shop types - item, demon fang, skill.
- Purchase hook for when item or skill gets purchased from a particular shop slot.
- Stock listing hooks for replacing icons and text based on shop slot.
- Hook to replace descriptions based on shop slot.
- Hooks to mark an item/skill as sold out and greyed if received by AP (should update instantly with multi-slot AP?).

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos
<!-- If applicable, show the changes in action -->

---

<!-- Thanks for contributing! -->
