### PR TITLE
Mod loader follow-ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ if(NOT BUILD_TESTS_ONLY)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/proxy-dll/modloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/proxy-dll/dinput8.def
   )
+  target_link_libraries(okami-proxy-dll PRIVATE minhook::minhook)
   target_compile_features(okami-proxy-dll PRIVATE ${STD_FEATURE})
   enable_strict_warnings(okami-proxy-dll)
   apply_release_optimizations(okami-proxy-dll)

--- a/include/okami/memorymap.hpp
+++ b/include/okami/memorymap.hpp
@@ -20,7 +20,6 @@ namespace okami
 {
 // Base addresses
 extern uintptr_t MainBase;
-extern uintptr_t FlowerBase;
 
 extern MemoryAccessor<CharacterStats> AmmyStats;
 extern MemoryAccessor<CollectionData> AmmyCollections;

--- a/src/client/gui.cpp
+++ b/src/client/gui.cpp
@@ -300,13 +300,9 @@ void guiInitHooks()
             {
                 std::this_thread::sleep_for(std::chrono::seconds(2));
                 getPresentFunctionPtr();
-
-                if (okami::D3D11PresentFnPtr)
-                {
-                    MH_CreateHook(okami::D3D11PresentFnPtr, reinterpret_cast<LPVOID>(&onRenderPresent), reinterpret_cast<LPVOID *>(&oPresent));
-                    MH_EnableHook(okami::D3D11PresentFnPtr);
-                }
             }
+            MH_CreateHook(okami::D3D11PresentFnPtr, reinterpret_cast<LPVOID>(&onRenderPresent), reinterpret_cast<LPVOID *>(&oPresent));
+            MH_EnableHook(okami::D3D11PresentFnPtr);
         })
         .detach();
 }

--- a/src/client/gui.cpp
+++ b/src/client/gui.cpp
@@ -293,14 +293,20 @@ void getPresentFunctionPtr()
 
 void guiInitHooks()
 {
-    getPresentFunctionPtr();
-
     std::thread(
         []
         {
-            std::this_thread::sleep_for(std::chrono::seconds(2));
-            MH_CreateHook(okami::D3D11PresentFnPtr, reinterpret_cast<LPVOID>(&onRenderPresent), reinterpret_cast<LPVOID *>(&oPresent));
-            MH_EnableHook(okami::D3D11PresentFnPtr);
+            while (okami::D3D11PresentFnPtr == nullptr)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(2));
+                getPresentFunctionPtr();
+
+                if (okami::D3D11PresentFnPtr)
+                {
+                    MH_CreateHook(okami::D3D11PresentFnPtr, reinterpret_cast<LPVOID>(&onRenderPresent), reinterpret_cast<LPVOID *>(&oPresent));
+                    MH_EnableHook(okami::D3D11PresentFnPtr);
+                }
+            }
         })
         .detach();
 }

--- a/src/library/memorymap.cpp
+++ b/src/library/memorymap.cpp
@@ -21,7 +21,6 @@ namespace okami
 {
 // Base addresses
 uintptr_t MainBase;
-uintptr_t FlowerBase;
 
 MemoryAccessor<CharacterStats> AmmyStats;
 MemoryAccessor<CollectionData> AmmyCollections;
@@ -55,7 +54,7 @@ void *MaybePlayerClassPtr;
 
 // Game function pointers
 
-void *D3D11PresentFnPtr;
+void *D3D11PresentFnPtr = nullptr;
 
 MemoryAccessor<BitField<32>> AmmyUsableBrushes;
 MemoryAccessor<BitField<32>> AmmyObtainedBrushes;

--- a/src/loader/main.cpp
+++ b/src/loader/main.cpp
@@ -2,7 +2,9 @@
 
 #include <filesystem>
 #include <format>
+#include <fstream>
 #include <iostream>
+#include <string>
 
 namespace fs = std::filesystem;
 
@@ -32,6 +34,13 @@ std::string formatWindowsError(DWORD error)
     return message;
 }
 
+void createModdedSignal()
+{
+    fs::path temp = fs::temp_directory_path() / "okami_modded_signal.txt";
+    fs::remove(temp);
+    std::ofstream{temp};
+}
+
 int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[])
 {
     std::cout << "Okami APClient Loader" << std::endl;
@@ -50,11 +59,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[])
         return error(std::format("Cannot find okami.exe at: {}", okamiExe.string()));
     }
 
+    createModdedSignal();
+
     STARTUPINFOW si{};
     PROCESS_INFORMATION pi{};
     std::wstring wideOkamiExe = okamiExe;
-    wchar_t args[256] = L" -MODDED";
-    if (!CreateProcessW(wideOkamiExe.c_str(), args, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi))
+    if (!CreateProcessW(wideOkamiExe.c_str(), nullptr, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi))
     {
         return error(std::format("Failed to launch okami.exe: {}", formatWindowsError(GetLastError())));
     }

--- a/src/proxy-dll/dinput8.cpp
+++ b/src/proxy-dll/dinput8.cpp
@@ -127,6 +127,7 @@ void LoadOriginalLibrary()
     dinput8.OriginalGetdfDIJoystick = GetProcAddress(dinput8.dll, "GetdfDIJoystick");
 }
 
+// This module is loaded while flower_kernel is loading, but before main.dll gets loaded, so not all hooking can happen immediately
 BOOL APIENTRY DllMain([[maybe_unused]] HMODULE hModule, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved)
 {
     switch (ul_reason_for_call)

--- a/src/proxy-dll/dinput8.cpp
+++ b/src/proxy-dll/dinput8.cpp
@@ -1,14 +1,17 @@
 // Mostly generated and then modified to work with non-VS, see README
 #include <Windows.h>
 
-#include <dinput.h>
+#include <iostream>
+#include <string>
 
 #include "modloader.h"
+
+#include <MinHook.h>
 
 static struct dinput8_dll
 {
     HMODULE dll;
-    decltype(DirectInput8Create) *OriginalDirectInput8Create;
+    FARPROC OriginalDirectInput8Create;
     FARPROC OriginalDllCanUnloadNow;
     FARPROC OriginalDllGetClassObject;
     FARPROC OriginalDllRegisterServer;
@@ -21,10 +24,9 @@ IMPORTANT:
   Originally used __asm tags and jmp, which is not cross-compiler compatible.
   Currently relies on whatever the compiler does, if it doesn't only generate a jmp instruction it can break.
 */
-HRESULT WINAPI FakeDirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID *ppvOut, LPUNKNOWN punkOuter)
+void __stdcall FakeDirectInput8Create()
 {
-    LoadMods();
-    return dinput8.OriginalDirectInput8Create(hinst, dwVersion, riidltf, ppvOut, punkOuter);
+    dinput8.OriginalDirectInput8Create();
 }
 void __stdcall FakeDllCanUnloadNow()
 {
@@ -47,31 +49,95 @@ void __stdcall FakeGetdfDIJoystick()
     dinput8.OriginalGetdfDIJoystick();
 }
 
-BOOL APIENTRY DllMain([[maybe_unused]] HMODULE hModule, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved)
+void error(const std::string &msg)
+{
+    MessageBox(nullptr, msg.c_str(), "Error", MB_ICONERROR);
+    std::cerr << msg << std::endl;
+}
+
+static bool(__fastcall *pOriginalFlowerStartup)(bool started);
+bool __fastcall OverrideFlowerStartup(bool started)
+{
+    if (!started)
+    {
+        LoadMods();
+    }
+    return pOriginalFlowerStartup(started);
+}
+
+static decltype(CreateWindowExW) *pOriginalCreateWindowExW;
+HWND WINAPI OverrideCreateWindowExW(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+                                    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    static bool initialized = false;
+    if (!initialized)
+    {
+        initialized = true;
+        if (MH_OK != MH_CreateHookApi(L"main.dll", "?flower_startup@@YA_N_N@Z", reinterpret_cast<LPVOID>(&OverrideFlowerStartup),
+                                      reinterpret_cast<LPVOID *>(&pOriginalFlowerStartup)))
+        {
+            error("Failed to hook flower_startup");
+        }
+        MH_EnableHook(MH_ALL_HOOKS);
+    }
+
+    return pOriginalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+}
+
+void InitiateMainHook()
+{
+    if (!IsModded())
+        return;
+
+    MH_Initialize();
+
+    // dinput8 gets loaded before main.dll so we hook something else and wait for that to be called
+    if (MH_OK != MH_CreateHookApi(L"User32.dll", "CreateWindowExW", reinterpret_cast<LPVOID>(&OverrideCreateWindowExW),
+                                  reinterpret_cast<LPVOID *>(&pOriginalCreateWindowExW)))
+    {
+        error("Failed to hook CreateWindowExW");
+    }
+    MH_EnableHook(MH_ALL_HOOKS);
+}
+
+void DestroyHooks()
+{
+    MH_DisableHook(MH_ALL_HOOKS);
+    MH_Uninitialize();
+}
+
+void LoadOriginalLibrary()
 {
     char path[MAX_PATH * 2];
+    GetSystemDirectoryA(path, MAX_PATH);
+    strcat(path, "\\dinput8.dll");
+
+    dinput8.dll = LoadLibraryA(path);
+    if (dinput8.dll == false)
+    {
+        MessageBoxA(0, "Cannot load original dinput8.dll library", "Proxy", MB_ICONERROR);
+        ExitProcess(0);
+    }
+
+    reinterpret_cast<FARPROC &>(dinput8.OriginalDirectInput8Create) = GetProcAddress(dinput8.dll, "DirectInput8Create");
+    dinput8.OriginalDllCanUnloadNow = GetProcAddress(dinput8.dll, "DllCanUnloadNow");
+    dinput8.OriginalDllGetClassObject = GetProcAddress(dinput8.dll, "DllGetClassObject");
+    dinput8.OriginalDllRegisterServer = GetProcAddress(dinput8.dll, "DllRegisterServer");
+    dinput8.OriginalDllUnregisterServer = GetProcAddress(dinput8.dll, "DllUnregisterServer");
+    dinput8.OriginalGetdfDIJoystick = GetProcAddress(dinput8.dll, "GetdfDIJoystick");
+}
+
+BOOL APIENTRY DllMain([[maybe_unused]] HMODULE hModule, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved)
+{
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
-        GetSystemDirectoryA(path, MAX_PATH);
-        strcat(path, "\\dinput8.dll");
-
-        dinput8.dll = LoadLibraryA(path);
-        if (dinput8.dll == false)
-        {
-            MessageBoxA(0, "Cannot load original dinput8.dll library", "Proxy", MB_ICONERROR);
-            ExitProcess(0);
-        }
-
-        reinterpret_cast<FARPROC &>(dinput8.OriginalDirectInput8Create) = GetProcAddress(dinput8.dll, "DirectInput8Create");
-        dinput8.OriginalDllCanUnloadNow = GetProcAddress(dinput8.dll, "DllCanUnloadNow");
-        dinput8.OriginalDllGetClassObject = GetProcAddress(dinput8.dll, "DllGetClassObject");
-        dinput8.OriginalDllRegisterServer = GetProcAddress(dinput8.dll, "DllRegisterServer");
-        dinput8.OriginalDllUnregisterServer = GetProcAddress(dinput8.dll, "DllUnregisterServer");
-        dinput8.OriginalGetdfDIJoystick = GetProcAddress(dinput8.dll, "GetdfDIJoystick");
+        LoadOriginalLibrary();
+        InitiateMainHook();
         break;
     case DLL_PROCESS_DETACH:
         UnloadMods();
+        DestroyHooks();
         FreeLibrary(dinput8.dll);
         break;
     }

--- a/src/proxy-dll/modloader.h
+++ b/src/proxy-dll/modloader.h
@@ -1,4 +1,5 @@
 #pragma once
 
+bool IsModded();
 void LoadMods();
 void UnloadMods();


### PR DESCRIPTION
## Description
Moves weird hook logic from apclient to proxy DLL and bypasses steam popup window.

## Changes
- Use temp file to indicate whether modded is being launched (can optionally use command line too if users want to launch modded from Steam).
- Move convoluted hooking logic from apclient to proxy dll.
- Hook even earlier, directly when flower_startup gets called.
- Retry UI hooks when they are too early.

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos
<!-- If applicable, show the changes in action -->

---

<!-- Thanks for contributing! -->
