### PR TITLE
Add llvm-mingw cross-compilation support for Linux

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -198,6 +198,48 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
+        },
+        {
+            "name": "llvm-mingw-cross-base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CXX_STD": "23",
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/external/vcpkg/scripts/buildsystems/vcpkg.cmake",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "VCPKG_TARGET_TRIPLET": "x64-mingw-llvm-static",
+                "VCPKG_HOST_TRIPLET": "x64-linux",
+                "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/llvm-mingw.cmake",
+                "VCPKG_OVERLAY_PORTS": "${sourceDir}/cmake/vcpkg-overlays",
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/cmake/vcpkg-overlays/triplets",
+                "VCPKG_APPLOCAL_DEPS": "OFF"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            },
+            "environment": {
+                "VCPKG_DEFAULT_TRIPLET": "x64-mingw-llvm-static",
+                "VCPKG_DEFAULT_HOST_TRIPLET": "x64-linux"
+            }
+        },
+        {
+            "name": "llvm-mingw-cross-debug",
+            "displayName": "Linux Cross Debug (llvm-mingw)",
+            "inherits": "llvm-mingw-cross-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "llvm-mingw-cross-release",
+            "displayName": "Linux Cross Release (llvm-mingw)",
+            "inherits": "llvm-mingw-cross-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
         }
     ],
     "buildPresets": [

--- a/cmake/toolchains/llvm-mingw.cmake
+++ b/cmake/toolchains/llvm-mingw.cmake
@@ -1,0 +1,55 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+# Find the llvm-mingw installation.
+# Set LLVM_MINGW_ROOT via environment variable or CMake cache variable.
+# Falls back to /opt/llvm-mingw if neither is set.
+# Download releases from https://github.com/mstorsjo/llvm-mingw/releases
+if(NOT DEFINED LLVM_MINGW_ROOT)
+    if(DEFINED ENV{LLVM_MINGW_ROOT})
+        set(LLVM_MINGW_ROOT "$ENV{LLVM_MINGW_ROOT}" CACHE PATH "llvm-mingw installation root")
+    else()
+        set(LLVM_MINGW_ROOT "/opt/llvm-mingw" CACHE PATH "llvm-mingw installation root")
+    endif()
+endif()
+
+find_program(CMAKE_C_COMPILER
+    NAMES x86_64-w64-mingw32-clang
+    PATHS "${LLVM_MINGW_ROOT}/bin"
+    NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER
+    NAMES x86_64-w64-mingw32-clang++
+    PATHS "${LLVM_MINGW_ROOT}/bin"
+    NO_DEFAULT_PATH)
+find_program(CMAKE_RC_COMPILER
+    NAMES x86_64-w64-mingw32-windres llvm-windres
+    PATHS "${LLVM_MINGW_ROOT}/bin"
+    NO_DEFAULT_PATH)
+
+if(NOT CMAKE_C_COMPILER OR NOT CMAKE_CXX_COMPILER)
+    message(FATAL_ERROR
+        "llvm-mingw not found at '${LLVM_MINGW_ROOT}'.\n"
+        "Download a Linux x86_64 release (ucrt variant) from:\n"
+        "  https://github.com/mstorsjo/llvm-mingw/releases\n"
+        "Extract it and set LLVM_MINGW_ROOT to the directory, e.g.:\n"
+        "  export LLVM_MINGW_ROOT=/opt/llvm-mingw")
+endif()
+
+# The sysroot lives inside the llvm-mingw installation
+set(CMAKE_FIND_ROOT_PATH "${LLVM_MINGW_ROOT}/x86_64-w64-mingw32")
+
+# Allow vcpkg paths to be searched alongside the sysroot
+if(VCPKG_TARGET_TRIPLET)
+    list(APPEND CMAKE_FIND_ROOT_PATH "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}")
+endif()
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+
+# Do NOT use -static here: UCRT is a Windows system DLL (always present on Win10+) and
+# is only available as a DLL import — forcing -static breaks __declspec(dllimport) resolution.
+# libc++ and libunwind are linked statically in the target CMakeLists instead.
+
+add_definitions(-D_WIN32_WINNT=0x0601)

--- a/cmake/vcpkg-overlays/triplets/x64-mingw-llvm-static.cmake
+++ b/cmake/vcpkg-overlays/triplets/x64-mingw-llvm-static.cmake
@@ -1,0 +1,20 @@
+# x64-mingw-llvm-static: like x64-mingw-static but for llvm-mingw (UCRT) toolchain.
+# Using a distinct triplet name prevents vcpkg from reusing GCC/MSVCRT-built packages.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_ENV_PASSTHROUGH PATH LLVM_MINGW_ROOT)
+
+set(VCPKG_CMAKE_SYSTEM_NAME MinGW)
+
+# Tell vcpkg to use the llvm-mingw Clang toolchain for cross-compiling packages.
+# Without this, vcpkg falls back to whatever MinGW GCC it finds on PATH, which causes
+# conflicts with our -D_vsnprintf=vsnprintf flag (GCC stdio.h declares vsnprintf with
+# C++ linkage, causing conflicting-declaration errors at compile time).
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../../toolchains/llvm-mingw.cmake")
+
+# llvm-mingw UCRT headers declare _vsnprintf as __declspec(dllimport) via _CRTIMP, but
+# provide no import library stub for it. Redirect to the standard vsnprintf (C99, no DLL
+# import) so packages like OpenSSL don't generate unresolvable __imp__vsnprintf references.
+set(VCPKG_C_FLAGS "-D_vsnprintf=vsnprintf")
+set(VCPKG_CXX_FLAGS "-D_vsnprintf=vsnprintf")

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,56 @@ cmake --build --preset x64-clang-debug
 - `x64-clang-release` - Release build with Clang
 - `x64-debug` - Debug build with MSVC
 - `x64-release` - Release build with MSVC
+- `linux-cross-debug` - Cross-compile for Windows from Linux using GCC MinGW-w64 (GCC 13.3+ required)
+- `linux-cross-release` - Release cross-compile for Windows from Linux using GCC MinGW-w64
+- `llvm-mingw-cross-debug` - Cross-compile for Windows from Linux using llvm-mingw (recommended)
+- `llvm-mingw-cross-release` - Release cross-compile for Windows from Linux using llvm-mingw
+
+### Linux Cross-Compilation
+
+Two toolchain options are available. **llvm-mingw is recommended** — it works on all
+distros including Ubuntu, and uses the same Clang compiler used for the Windows builds.
+
+#### Option A: llvm-mingw (Recommended)
+
+[llvm-mingw](https://github.com/mstorsjo/llvm-mingw) is a Clang/LLVM-based MinGW-w64
+toolchain that builds cleanly on all Linux distros.
+
+1. Download the latest Linux x86_64 UCRT release from
+   [github.com/mstorsjo/llvm-mingw/releases](https://github.com/mstorsjo/llvm-mingw/releases).
+   The filename looks like `llvm-mingw-YYYYMMDD-ucrt-ubuntu-20.04-x86_64.tar.xz`.
+
+2. Extract it and set the `LLVM_MINGW_ROOT` environment variable:
+
+   ```bash
+   sudo tar -xf llvm-mingw-*-ucrt-ubuntu-20.04-x86_64.tar.xz -C /opt
+   sudo mv /opt/llvm-mingw-* /opt/llvm-mingw
+   export LLVM_MINGW_ROOT=/opt/llvm-mingw   # add to ~/.bashrc to persist
+   ```
+
+3. Build using the `llvm-mingw-cross-*` presets:
+
+   ```bash
+   cmake --preset llvm-mingw-cross-debug
+   cmake --build --preset llvm-mingw-cross-debug
+   ```
+
+#### Option B: GCC MinGW-w64 (GCC 13.3+ required)
+
+```bash
+sudo apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 ninja-build
+cmake --preset linux-cross-debug
+cmake --build --preset linux-cross-debug
+```
+
+> **Ubuntu compatibility:** Ubuntu ships GCC 13.2 for `gcc-mingw-w64-x86-64` across all
+> releases through 25.10, with no newer version available via apt. GCC 13.2 rejects the
+> template-id constructor syntax in `websocketpp` as a hard parse error in C++20 mode
+> ([CWG DR 2037][cwgdr2037]) with no pragma-level workaround. The CMake configure step
+> will fail with an actionable error message on unsupported compilers.
+> **Fedora** (and other distros that ship GCC 13.3+) cross-compile without issue.
+
+[cwgdr2037]: https://cplusplus.github.io/CWG/issues/2037.html
 
 ### Custom Ninja Path
 

--- a/include/wolf_framework.hpp
+++ b/include/wolf_framework.hpp
@@ -38,6 +38,7 @@
 // Core runtime API (uses function table)
 
 // === Expanded from wolf_core.hpp ===
+#include <atomic>
 #include <cassert>
 #include <cstdarg>
 #include <cstdint>
@@ -2502,6 +2503,15 @@ template <typename T> class MemoryAccessor
     T *operator->() const
     {
         return get_ptr();
+    }
+
+    /**
+     * @brief Dereference operator for reference-style access
+     * @return Reference to memory location
+     */
+    T &operator*() const
+    {
+        return *get_ptr();
     }
 };
 

--- a/src/okami-apclient/CMakeLists.txt
+++ b/src/okami-apclient/CMakeLists.txt
@@ -53,6 +53,41 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CROSS_COMPILING_WINDOWS)
         -static
         LINKER:--allow-multiple-definition
         LINKER:--enable-stdcall-fixup)
+    # websocketpp uses template-id ctor/dtor syntax (e.g. basic<T,U>()) which is ill-formed
+    # in C++20 per CWG DR 2037. GCC 13.3+ demotes this to a suppressible warning via
+    # -Wno-template-id-cdtor. GCC 13.2 and earlier treat it as a hard parse error with no
+    # workaround short of modifying the library. Ubuntu ships GCC 13.2 for mingw-w64 across
+    # all releases through 25.10 with no newer package available via apt.
+    # Minimum required MinGW-w64 cross-compiler: GCC 13.3.0
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13.3.0")
+        message(FATAL_ERROR
+            "MinGW-w64 cross-compiler GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.\n"
+            "websocketpp uses template-id ctor/dtor syntax (CWG DR 2037) that GCC < 13.3 "
+            "rejects as a hard parse error in C++20 mode with no pragma-level workaround.\n"
+            "Ubuntu 24.04–25.10 only ship GCC 13.2 for mingw-w64 (no newer apt package).\n"
+            "To cross-compile, use llvm-mingw (cmake/toolchains/llvm-mingw.cmake) "
+            "or a system with GCC 13.3+ mingw-w64 (e.g. Fedora), "
+            "or build using the Windows/MSVC presets instead.")
+    else()
+        target_compile_options(okami-apclient PRIVATE -Wno-template-id-cdtor)
+    endif()
+    # Remove lib prefix and skip import library generation
+    set_target_properties(okami-apclient PROPERTIES
+        PREFIX ""
+        IMPORT_SUFFIX ""
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/implib")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CROSS_COMPILING_WINDOWS)
+    # llvm-mingw cross-compilation: Clang uses the LLVM integrated assembler (no -Wa,-mbig-obj
+    # needed) and has no libgcc (no -static-libgcc). websocketpp compiles cleanly with Clang.
+    # UCRT is a Windows system DLL (present on Win10+); don't force -static which would break
+    # its __declspec(dllimport) symbols. Instead, link libc++/libunwind as static archives so
+    # the DLL has no dependency on libc++.dll or libunwind.dll.
+    target_link_libraries(okami-apclient PRIVATE dwmapi d3dcompiler)
+    target_compile_options(okami-apclient PRIVATE -g1)
+    target_link_options(okami-apclient PRIVATE
+        LINKER:--allow-multiple-definition
+        LINKER:--enable-stdcall-fixup)
+    target_link_libraries(okami-apclient PRIVATE -l:libc++.a -l:libc++abi.a -l:libunwind.a)
     # Remove lib prefix and skip import library generation
     set_target_properties(okami-apclient PROPERTIES
         PREFIX ""

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,5 +104,14 @@ include(CTest)
 
 # Include Catch2's test discovery
 include(Catch)
-catch_discover_tests(apclient-tests)
-catch_discover_tests(apclient-harness-tests)
+
+# When cross-compiling (e.g. Windows EXEs built on Linux), running the executable
+# at build time for POST_BUILD test discovery will fail. Defer to PRE_TEST so the
+# build succeeds; test discovery runs at CTest invocation time instead.
+if(CMAKE_CROSSCOMPILING)
+    set(CATCH_DISCOVERY_MODE DISCOVERY_MODE PRE_TEST)
+else()
+    set(CATCH_DISCOVERY_MODE "")
+endif()
+catch_discover_tests(apclient-tests ${CATCH_DISCOVERY_MODE})
+catch_discover_tests(apclient-harness-tests ${CATCH_DISCOVERY_MODE})


### PR DESCRIPTION
Adds a Clang-based cross-compilation path using llvm-mingw (UCRT toolchain) as an alternative to the GCC MinGW-w64 path. This avoids the hard GCC 13.3.0 requirement for websocketpp compatibility in C++23 mode (Ubuntu ships GCC 13.2 for mingw-w64 through all releases up to 25.10).