### PR TITLE
Feat/save manager

### DIFF
--- a/include/okami/offsets.hpp
+++ b/include/okami/offsets.hpp
@@ -43,6 +43,12 @@ constexpr uintptr_t mapData = 0xB322B0; // std::array<MapState, MapTypes::NUM_MA
 /// Dialog/interaction bits for all maps
 constexpr uintptr_t dialogBits = 0xB36CF0; // std::array<BitField<512>, MapTypes::NUM_MAP_TYPES>
 
+/// Custom textures (free-draw textures, e.g. Moon Cave mask)
+constexpr uintptr_t customTextures = 0xB21820; // CustomTextures
+
+/// Area name string ID (written into save slot header)
+constexpr uintptr_t areaNameStrId = 0x79BEB4; // uint32_t
+
 //==============================================================================
 // GAME STATE & UI
 //==============================================================================

--- a/src/okami-apclient/checkman.cpp
+++ b/src/okami-apclient/checkman.cpp
@@ -220,6 +220,9 @@ void CheckMan::sendCheck(int64_t checkId)
     markCheckSent(checkId);
 
     wolf::logInfo("[CheckMan] Sent check: %" PRId64 " (total: %zu)", checkId, sentChecks_.size());
+
+    if (onCheckSentCallback_)
+        onCheckSentCallback_();
 }
 
 bool CheckMan::hasCheckBeenSent(int64_t checkId) const
@@ -276,6 +279,11 @@ void CheckMan::destroyMonitors()
         wolf::destroyBitfieldMonitor(gameProgressMonitor_);
         gameProgressMonitor_ = nullptr;
     }
+}
+
+void CheckMan::setOnCheckSentCallback(std::function<void()> callback)
+{
+    onCheckSentCallback_ = std::move(callback);
 }
 
 bool CheckMan::isContainerInRando(int64_t locationId) const

--- a/src/okami-apclient/checkman.cpp
+++ b/src/okami-apclient/checkman.cpp
@@ -113,6 +113,14 @@ bool CheckMan::isSendingEnabled() const
 
 void CheckMan::poll()
 {
+    // Lazily create brush handler once slot config arrives (connection happens after init)
+    if (!brushHandler_ && socket_.isSlotConfigReady() && socket_.getSlotConfig().randomizeBrushes)
+    {
+        auto callback = [this](int64_t checkId) { sendCheck(checkId); };
+        brushHandler_ = std::make_unique<checks::BrushMan>(callback);
+        brushHandler_->initialize();
+    }
+
     if (containerHandler_)
     {
         containerHandler_->poll();

--- a/src/okami-apclient/checkman.h
+++ b/src/okami-apclient/checkman.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <memory>
 #include <unordered_set>
@@ -124,6 +125,12 @@ class CheckMan
      */
     [[nodiscard]] bool isContainerInRando(int64_t locationId) const;
 
+    /**
+     * @brief Set callback to be invoked after a check is sent
+     * @param callback Function to call (e.g., SaveMan::queueAutoSave)
+     */
+    void setOnCheckSentCallback(std::function<void()> callback);
+
   private:
     /**
      * @brief Send a check to the server
@@ -170,6 +177,9 @@ class CheckMan
 
     // Shop handler (owns hooks and shop definitions)
     std::unique_ptr<checks::ShopMan> shopHandler_;
+
+    // Callback invoked after each check is sent (for auto-save)
+    std::function<void()> onCheckSentCallback_;
 
     // Initialization state
     bool initialized_ = false;

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -7,6 +7,7 @@
 #include "gamestate_accessors.hpp"
 #include "itempatch.hpp"
 #include "rewardman.h"
+#include "saveman.h"
 #include "ui/loginwindow.h"
 #include "ui/notificationwindow.h"
 #include "ui/warpwindow.h"
@@ -22,6 +23,7 @@
 // Global manager instances
 static std::unique_ptr<RewardMan> g_rewardMan;
 static std::unique_ptr<CheckMan> g_checkMan;
+static std::unique_ptr<SaveMan> g_saveMan;
 
 // GUI window name for wolf registration
 static const char *g_guiWindowName = "APClient GUI";
@@ -86,6 +88,11 @@ class APClientMod
         // Patch ItemParam array to prevent shop crashes
         itempatch::patchItemParams();
 
+        // Create save manager and install save/load hooks
+        g_saveMan = std::make_unique<SaveMan>(ArchipelagoSocket::instance());
+        g_saveMan->initialize();
+        g_saveMan->installHooks();
+
         // Create managers with explicit dependencies
         g_checkMan = std::make_unique<CheckMan>(ArchipelagoSocket::instance());
 
@@ -106,10 +113,36 @@ class APClientMod
         // Initialize UI
         initializeGui();
         loginwindow::initialize(ArchipelagoSocket::instance());
+        loginwindow::setSaveMan(g_saveMan.get());
         warpwindow::initialize();
 
         // Initialize check manager (sets up monitors and container hooks)
         g_checkMan->initialize();
+
+        // Wire auto-save: queue save after each check is sent
+        g_checkMan->setOnCheckSentCallback([]() {
+            if (g_saveMan)
+                g_saveMan->queueAutoSave();
+        });
+
+        // AP mode lifecycle: activate on play start (if connected).
+        // If a pending AP load was flagged by hookMcLoadCtor, restore game state now
+        // (after the game has finished loading the vanilla save into memory).
+        wolf::onPlayStart([]() {
+            if (g_saveMan && ArchipelagoSocket::instance().isConnected())
+            {
+                g_saveMan->setApModeActive(true);
+                if (g_saveMan->isPendingLoad())
+                {
+                    g_saveMan->loadGameState();
+                    g_saveMan->setPendingLoad(false);
+                }
+            }
+        });
+        wolf::onReturnToMenu([]() {
+            if (g_saveMan)
+                g_saveMan->setApModeActive(false);
+        });
 
         // Game tick handler
         wolf::onGameTick(
@@ -119,6 +152,8 @@ class APClientMod
                 ArchipelagoSocket::instance().poll();
                 g_rewardMan->processQueuedRewards();
                 g_checkMan->poll();
+                if (g_saveMan)
+                    g_saveMan->processAutoSave();
             });
     }
 
@@ -130,6 +165,7 @@ class APClientMod
         }
         g_checkMan.reset();
         g_rewardMan.reset();
+        g_saveMan.reset();
         warpwindow::shutdown();
         notificationwindow::shutdown();
         loginwindow::shutdown();

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -28,7 +28,7 @@ static std::unique_ptr<SaveMan> g_saveMan;
 // GUI window name for wolf registration
 static const char *g_guiWindowName = "APClient GUI";
 
-// Main GUI render function - calls all internal windows
+// Main GUI render function
 static void renderGui(int outerWidth, int outerHeight, [[maybe_unused]] float uiScale)
 {
 #ifdef _WIN32

--- a/src/okami-apclient/saveman.cpp
+++ b/src/okami-apclient/saveman.cpp
@@ -1,0 +1,527 @@
+#include "saveman.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+#include <wolf_framework.hpp>
+
+#include "isocket.h"
+#include "ui/notificationwindow.h"
+#include <okami/offsets.hpp>
+
+static std::string initSaveDir()
+{
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+    const char *appdata = std::getenv("APPDATA");
+#pragma warning(pop)
+    if (appdata)
+        return std::string(appdata) + "\\okami-apsaves";
+    return "okami-apsaves"; // fallback
+#else
+    // Non-Windows (test builds): use $HOME or /tmp
+    const char *home = std::getenv("HOME");
+    if (home)
+        return std::string(home) + "/.okami-apsaves";
+    return "/tmp/okami-apsaves";
+#endif
+}
+static const std::string SAVE_DIR = initSaveDir();
+
+namespace
+{
+// Memory region addresses (offsets relative to main.dll)
+constexpr uintptr_t kCharacterStats = okami::main::characterStats;   // 0xB4DF90
+constexpr uintptr_t kTrackerData = okami::main::trackerData;         // 0xB21780
+constexpr uintptr_t kCollectionData = okami::main::collectionData;   // 0xB205D0
+constexpr uintptr_t kMapData = okami::main::mapData;                 // 0xB322B0
+constexpr uintptr_t kDialogBits = okami::main::dialogBits;           // 0xB36CF0
+constexpr uintptr_t kCustomTextures = okami::main::customTextures;   // 0xB21820
+constexpr uintptr_t kAreaNameStrId = okami::main::areaNameStrId;     // 0x79BEB4
+
+constexpr uint64_t kChecksumSeed = 0x9be6fa3b72afda1d;
+constexpr uint32_t kHeaderMagic = 0x40400000;
+
+// Hook offsets (relative to main.dll base)
+constexpr uintptr_t kMcLoadCtorOffset = 0x1c1db0;     // FUN_1801c1db0: cMcLoad constructor
+constexpr uintptr_t kMcSaveCtorOffset = 0x1c3de0;     // FUN_1801c3de0: cMcSave constructor
+constexpr uintptr_t kSaveGateOffset = 0x1c37d0;       // FUN_1801c37d0: cMcSave gate (vtable[1])
+                                                        //   returns 1 → show save UI, 0 → skip to cleanup
+constexpr uintptr_t kCurrentSlotIndex = 0x79BEB0;     // Active save slot index (uint32_t)
+} // namespace
+
+static_assert(sizeof(okami::SaveSlot) == 0x172A0,
+              "SaveSlot size mismatch — expected 0x172A0 bytes");
+
+// =============================================================================
+// Hook infrastructure
+// =============================================================================
+
+// Raw pointer for hook callbacks — set by installHooks(), cleared by destructor.
+static SaveMan *g_saveMan = nullptr;
+
+// Function signatures (x64 __fastcall, from Ghidra decompilation)
+using CtorFn = void(__fastcall *)(void *pContext);
+using GateFn = unsigned char(__fastcall *)(void *pMcSave);
+
+// Original function pointers (populated by hookFunction)
+static CtorFn s_origMcLoadCtor = nullptr;
+static CtorFn s_origMcSaveCtor = nullptr;
+static GateFn s_origSaveGate = nullptr;
+
+/// Hook: cMcSave gate function (FUN_1801c37d0, vtable[1]).
+/// Called by the state machine (FUN_1801bfcb0) to decide whether to show the save UI.
+/// Returns 1 → allocate buffers and open save slot picker (state 0).
+/// Returns 0 → skip directly to cleanup (state 2), no UI ever shown.
+/// When AP is connected, we return 0 so the vanilla save menu never opens.
+static unsigned char __fastcall hookSaveGate(void *pMcSave)
+{
+    if (g_saveMan && g_saveMan->isConnected())
+    {
+        // Let the original run (allocates save buffers that cleanup expects to exist),
+        // but override the return value so the state machine skips to state 2 (cleanup)
+        // instead of state 0 (show save UI).
+        s_origSaveGate(pMcSave);
+        wolf::logInfo("[SaveMan] Save gate: blocking vanilla save UI (AP connected)");
+        return 0;
+    }
+    return s_origSaveGate(pMcSave);
+}
+
+/// Hook: cMcLoad constructor — when the user clicked "Continue AP Game" in the
+/// login window, force slot 0 so the vanilla load completes quickly. The actual
+/// AP restore happens in onPlayStart after the game finishes loading.
+static void __fastcall hookMcLoadCtor(void *pContext)
+{
+    wolf::logDebug("[SaveMan] hookMcLoadCtor fired (pendingLoad=%d)",
+                   g_saveMan ? (int)g_saveMan->isPendingLoad() : -1);
+    if (g_saveMan && g_saveMan->isPendingLoad())
+    {
+        // Force slot 0 so the game has something to load (onPlayStart will overwrite)
+        uintptr_t slotAddr = wolf::getModuleBase("main.dll") + kCurrentSlotIndex;
+        uint32_t slot = 0;
+        wolf::writeMemory(slotAddr, &slot, sizeof(slot));
+
+        g_saveMan->setApModeActive(true);
+        wolf::logInfo("[SaveMan] AP load: forcing slot 0, will restore on play start");
+    }
+    s_origMcLoadCtor(pContext);
+}
+
+/// Hook: cMcSave constructor — when AP connected, snapshot game state to .oksav.
+/// The vanilla ctor still runs afterward, but hookSaveGate returns 0 so the state
+/// machine skips directly to cleanup — no save slot picker, no Steam Cloud write.
+static void __fastcall hookMcSaveCtor(void *pContext)
+{
+    wolf::logDebug("[SaveMan] hookMcSaveCtor fired (connected=%d)",
+                   g_saveMan ? (int)g_saveMan->isConnected() : -1);
+    if (g_saveMan && g_saveMan->isConnected())
+    {
+        g_saveMan->setApModeActive(true);
+        g_saveMan->saveGameState();
+        notificationwindow::queue("AP progress saved", 3.0f);
+        wolf::logInfo("[SaveMan] AP save: game state saved to %s", g_saveMan->getSavePath().c_str());
+    }
+    s_origMcSaveCtor(pContext);
+}
+
+SaveMan::SaveMan(ISocket &socket) : socket_(socket)
+{
+}
+
+SaveMan::~SaveMan()
+{
+    if (g_saveMan == this)
+        g_saveMan = nullptr;
+}
+
+void SaveMan::initialize()
+{
+    uintptr_t base = wolf::getModuleBase("main.dll");
+    if (base == 0)
+    {
+        wolf::logError("[SaveMan] Failed to get main.dll base address");
+        return;
+    }
+
+    characterStatsAddr_ = base + kCharacterStats;
+    trackerDataAddr_ = base + kTrackerData;
+    collectionDataAddr_ = base + kCollectionData;
+    mapDataAddr_ = base + kMapData;
+    dialogBitsAddr_ = base + kDialogBits;
+    customTexturesAddr_ = base + kCustomTextures;
+    areaNameStrIdAddr_ = base + kAreaNameStrId;
+
+    initialized_ = true;
+    wolf::logInfo("[SaveMan] Initialized (base=0x%llX)", base);
+}
+
+// =============================================================================
+// Core save/load
+// =============================================================================
+
+bool SaveMan::saveGameState()
+{
+    if (!initialized_)
+    {
+        wolf::logError("[SaveMan] Not initialized");
+        return false;
+    }
+
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+
+    snapshotToSlot(slot);
+    slot.checksum = computeChecksum(slot);
+
+    if (!writeSlotToFile(slot))
+    {
+        wolf::logError("[SaveMan] Failed to write save file");
+        return false;
+    }
+
+    wolf::logInfo("[SaveMan] Game state saved to %s", getSavePath().c_str());
+    return true;
+}
+
+bool SaveMan::loadGameState()
+{
+    if (!initialized_)
+    {
+        wolf::logError("[SaveMan] Not initialized");
+        return false;
+    }
+
+    okami::SaveSlot slot;
+    if (!readSlotFromFile(slot))
+    {
+        wolf::logError("[SaveMan] Failed to read save file");
+        return false;
+    }
+
+    // Verify checksum
+    uint64_t expected = computeChecksum(slot);
+    if (slot.checksum != expected)
+    {
+        wolf::logWarning("[SaveMan] Checksum mismatch (file=0x%llX, computed=0x%llX) — loading anyway",
+                         slot.checksum, expected);
+    }
+
+    restoreFromSlot(slot);
+    wolf::logInfo("[SaveMan] Game state loaded from %s", getSavePath().c_str());
+    return true;
+}
+
+bool SaveMan::hasSaveFile() const
+{
+    std::string path = getSavePath();
+    if (path.empty())
+        return false;
+    return std::filesystem::exists(path);
+}
+
+bool SaveMan::deleteSave()
+{
+    std::string path = getSavePath();
+    if (path.empty())
+        return false;
+
+    std::error_code ec;
+    if (std::filesystem::remove(path, ec))
+    {
+        wolf::logInfo("[SaveMan] Deleted save file: %s", path.c_str());
+        return true;
+    }
+    return false;
+}
+
+// =============================================================================
+// AP mode
+// =============================================================================
+
+bool SaveMan::isApModeActive() const
+{
+    return apModeActive_;
+}
+
+void SaveMan::setApModeActive(bool active)
+{
+    apModeActive_ = active;
+    wolf::logInfo("[SaveMan] AP mode %s", active ? "activated" : "deactivated");
+}
+
+bool SaveMan::isConnected() const
+{
+    return socket_.isConnected();
+}
+
+void SaveMan::setPendingLoad(bool pending)
+{
+    pendingApLoad_ = pending;
+}
+
+bool SaveMan::isPendingLoad() const
+{
+    return pendingApLoad_;
+}
+
+// =============================================================================
+// Auto-save
+// =============================================================================
+
+void SaveMan::queueAutoSave()
+{
+    std::lock_guard<std::mutex> lock(autoSaveMutex_);
+    autoSavePending_ = true;
+    lastAutoSaveRequest_ = std::chrono::steady_clock::now();
+}
+
+void SaveMan::processAutoSave()
+{
+    if (!autoSavePending_ || !apModeActive_)
+        return;
+
+    auto now = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(autoSaveMutex_);
+        if (now - lastAutoSaveRequest_ < AUTO_SAVE_DEBOUNCE)
+            return;
+        autoSavePending_ = false;
+    }
+
+    saveGameState();
+}
+
+// =============================================================================
+// Save path
+// =============================================================================
+
+std::string SaveMan::getSavePath() const
+{
+    if (!socket_.isConnected())
+        return {};
+
+    // Save key format: slot_seed (same as ArchipelagoSocket::getConnectionInfo)
+    std::string saveKey = socket_.getConnectionInfo();
+    if (saveKey.empty())
+        return {};
+
+    return (std::filesystem::path(SAVE_DIR) / (saveKey + ".oksav")).string();
+}
+
+// =============================================================================
+// Memory snapshot
+// =============================================================================
+
+void SaveMan::snapshotToSlot(okami::SaveSlot &slot)
+{
+    // Header
+    slot.header = kHeaderMagic;
+
+    // Area name string ID
+    slot.areaNameStrId = *reinterpret_cast<const uint32_t *>(areaNameStrIdAddr_);
+
+    // RTC timestamp (Windows FILETIME format for compatibility)
+    auto now = std::chrono::system_clock::now();
+    auto duration = now.time_since_epoch();
+    // Convert to Windows FILETIME (100-ns intervals since 1601-01-01)
+    // Unix epoch to FILETIME epoch offset: 116444736000000000
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
+    slot.timeRTC = static_cast<uint64_t>(us * 10) + 116444736000000000ULL;
+
+    // Copy the 6 game state regions
+    std::memcpy(&slot.character, reinterpret_cast<const void *>(characterStatsAddr_),
+                sizeof(okami::CharacterStats));
+
+    std::memcpy(&slot.tracked, reinterpret_cast<const void *>(trackerDataAddr_),
+                sizeof(okami::TrackerData));
+
+    std::memcpy(&slot.collection, reinterpret_cast<const void *>(collectionDataAddr_),
+                sizeof(okami::CollectionData));
+
+    std::memcpy(slot.MapData, reinterpret_cast<const void *>(mapDataAddr_),
+                sizeof(slot.MapData));
+
+    std::memcpy(slot.DialogBits, reinterpret_cast<const void *>(dialogBitsAddr_),
+                sizeof(slot.DialogBits));
+
+    std::memcpy(&slot.customTextures, reinterpret_cast<const void *>(customTexturesAddr_),
+                sizeof(okami::CustomTextures));
+}
+
+void SaveMan::restoreFromSlot(const okami::SaveSlot &slot)
+{
+    // Write the 6 game state regions back to game memory
+    std::memcpy(reinterpret_cast<void *>(characterStatsAddr_), &slot.character,
+                sizeof(okami::CharacterStats));
+
+    std::memcpy(reinterpret_cast<void *>(trackerDataAddr_), &slot.tracked,
+                sizeof(okami::TrackerData));
+
+    std::memcpy(reinterpret_cast<void *>(collectionDataAddr_), &slot.collection,
+                sizeof(okami::CollectionData));
+
+    std::memcpy(reinterpret_cast<void *>(mapDataAddr_), slot.MapData,
+                sizeof(slot.MapData));
+
+    std::memcpy(reinterpret_cast<void *>(dialogBitsAddr_), slot.DialogBits,
+                sizeof(slot.DialogBits));
+
+    std::memcpy(reinterpret_cast<void *>(customTexturesAddr_), &slot.customTextures,
+                sizeof(okami::CustomTextures));
+
+    // Write area name string ID back
+    *reinterpret_cast<uint32_t *>(areaNameStrIdAddr_) = slot.areaNameStrId;
+}
+
+// =============================================================================
+// Checksum (ported from OriginEdit — XOR all qwords except the checksum field)
+// =============================================================================
+
+uint64_t SaveMan::computeChecksum(const okami::SaveSlot &slot)
+{
+    const auto *data = reinterpret_cast<const uint64_t *>(&slot);
+    constexpr size_t totalQwords = sizeof(okami::SaveSlot) / sizeof(uint64_t);
+
+    // Seed XOR'd with first qword (header + areaNameStrId)
+    uint64_t checksum = kChecksumSeed ^ data[0];
+
+    // Skip data[1] (the checksum field at offset +0x08)
+    // XOR all qwords from offset +0x10 onward
+    for (size_t i = 2; i < totalQwords; ++i)
+    {
+        checksum ^= data[i];
+    }
+
+    return checksum;
+}
+
+// =============================================================================
+// File I/O
+// =============================================================================
+
+bool SaveMan::writeSlotToFile(const okami::SaveSlot &slot)
+{
+    std::string path = getSavePath();
+    if (path.empty())
+        return false;
+
+    try
+    {
+        std::filesystem::create_directories(SAVE_DIR);
+
+        // Atomic write: write to .tmp, then rename
+        std::string tmpPath = path + ".tmp";
+
+        std::ofstream file(tmpPath, std::ios::binary);
+        if (!file.is_open())
+        {
+            wolf::logError("[SaveMan] Failed to open %s for writing", tmpPath.c_str());
+            return false;
+        }
+
+        file.write(reinterpret_cast<const char *>(&slot), sizeof(okami::SaveSlot));
+        file.close();
+
+        if (!file.good())
+        {
+            wolf::logError("[SaveMan] Write error to %s", tmpPath.c_str());
+            std::filesystem::remove(tmpPath);
+            return false;
+        }
+
+        // Atomic rename
+        std::error_code ec;
+        std::filesystem::rename(tmpPath, path, ec);
+        if (ec)
+        {
+            wolf::logError("[SaveMan] Failed to rename %s -> %s: %s",
+                           tmpPath.c_str(), path.c_str(), ec.message().c_str());
+            std::filesystem::remove(tmpPath);
+            return false;
+        }
+
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        wolf::logError("[SaveMan] Exception writing save: %s", e.what());
+        return false;
+    }
+}
+
+bool SaveMan::readSlotFromFile(okami::SaveSlot &slot) const
+{
+    std::string path = getSavePath();
+    if (path.empty())
+        return false;
+
+    try
+    {
+        auto fileSize = std::filesystem::file_size(path);
+        if (fileSize != sizeof(okami::SaveSlot))
+        {
+            wolf::logError("[SaveMan] Invalid save file size: %zu (expected %zu)",
+                           static_cast<size_t>(fileSize), sizeof(okami::SaveSlot));
+            return false;
+        }
+
+        std::ifstream file(path, std::ios::binary);
+        if (!file.is_open())
+        {
+            wolf::logError("[SaveMan] Failed to open %s for reading", path.c_str());
+            return false;
+        }
+
+        file.read(reinterpret_cast<char *>(&slot), sizeof(okami::SaveSlot));
+
+        if (!file.good())
+        {
+            wolf::logError("[SaveMan] Read error from %s", path.c_str());
+            return false;
+        }
+
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        wolf::logError("[SaveMan] Exception reading save: %s", e.what());
+        return false;
+    }
+}
+
+// =============================================================================
+// Hook installation
+// =============================================================================
+
+void SaveMan::installHooks()
+{
+    g_saveMan = this;
+    int installed = 0;
+
+    if (wolf::hookFunction("main.dll", kMcLoadCtorOffset,
+                           reinterpret_cast<void *>(&hookMcLoadCtor),
+                           reinterpret_cast<void **>(&s_origMcLoadCtor)))
+        ++installed;
+    else
+        wolf::logError("[SaveMan] FAILED: McLoad ctor hook at 0x%zX", kMcLoadCtorOffset);
+
+    if (wolf::hookFunction("main.dll", kMcSaveCtorOffset,
+                           reinterpret_cast<void *>(&hookMcSaveCtor),
+                           reinterpret_cast<void **>(&s_origMcSaveCtor)))
+        ++installed;
+    else
+        wolf::logError("[SaveMan] FAILED: McSave ctor hook at 0x%zX", kMcSaveCtorOffset);
+
+    if (wolf::hookFunction("main.dll", kSaveGateOffset,
+                           reinterpret_cast<void *>(&hookSaveGate),
+                           reinterpret_cast<void **>(&s_origSaveGate)))
+        ++installed;
+    else
+        wolf::logError("[SaveMan] FAILED: SaveGate hook at 0x%zX", kSaveGateOffset);
+
+    wolf::logInfo("[SaveMan] Hooks installed: %d/3", installed);
+}

--- a/src/okami-apclient/saveman.h
+++ b/src/okami-apclient/saveman.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+
+#include <okami/savefile.hpp>
+
+class ISocket;
+
+/**
+ * @brief AP save file manager (Strategy B: direct memory snapshot)
+ *
+ * Reads/writes game state directly from/to the 6 known memory regions,
+ * completely bypassing the game's Steam Cloud save pipeline.
+ * AP saves are stored as single-slot .oksav files in %APPDATA%/okami-apsaves/.
+ */
+class SaveMan
+{
+  public:
+    explicit SaveMan(ISocket &socket);
+    ~SaveMan();
+
+    /// Initialize memory accessors. Must be called after main.dll is loaded.
+    void initialize();
+
+    // === Core save/load ===
+
+    /// Snapshot all 6 memory regions, compute checksum, write to AP file
+    bool saveGameState();
+
+    /// Read AP file, verify checksum, write all 6 memory regions back
+    bool loadGameState();
+
+    /// Check if an AP save exists for the current connection
+    bool hasSaveFile() const;
+
+    /// Delete the AP save for the current connection
+    bool deleteSave();
+
+    // === AP mode management ===
+
+    bool isApModeActive() const;
+    void setApModeActive(bool active);
+    bool isConnected() const;
+
+    /// Flag a pending AP restore — set by McLoadCtor hook, consumed by onPlayStart.
+    void setPendingLoad(bool pending);
+    bool isPendingLoad() const;
+
+    // === Auto-save support ===
+
+    /// Queue an auto-save (called after check send)
+    void queueAutoSave();
+
+    /// Process pending auto-save with debounce (called from game tick)
+    void processAutoSave();
+
+    /// Get the full path to the current AP save file
+    std::string getSavePath() const;
+
+    // === Hooks ===
+
+    /// Install hooks on the game's save/load functions.
+    /// Must be called after initialize().
+    void installHooks();
+
+    /// Compute XOR checksum (seed 0x9be6fa3b72afda1d) matching the game's algorithm.
+    /// Covers slot[0] (header) and slot[0x10..end], skipping the checksum field at +0x08.
+    static uint64_t computeChecksum(const okami::SaveSlot &slot);
+
+  private:
+    ISocket &socket_;
+    std::atomic<bool> apModeActive_{false};
+    std::atomic<bool> pendingApLoad_{false};
+    bool initialized_ = false;
+
+    // === Memory snapshot helpers ===
+    void snapshotToSlot(okami::SaveSlot &slot);
+    void restoreFromSlot(const okami::SaveSlot &slot);
+
+    // === File I/O ===
+    bool writeSlotToFile(const okami::SaveSlot &slot);
+    bool readSlotFromFile(okami::SaveSlot &slot) const;
+
+    // === Auto-save state ===
+    std::atomic<bool> autoSavePending_{false};
+    std::chrono::steady_clock::time_point lastAutoSaveRequest_;
+    std::mutex autoSaveMutex_;
+    static constexpr auto AUTO_SAVE_DEBOUNCE = std::chrono::milliseconds(500);
+
+    // === Memory addresses (resolved at init) ===
+    uintptr_t characterStatsAddr_ = 0;
+    uintptr_t trackerDataAddr_ = 0;
+    uintptr_t collectionDataAddr_ = 0;
+    uintptr_t mapDataAddr_ = 0;
+    uintptr_t dialogBitsAddr_ = 0;
+    uintptr_t customTexturesAddr_ = 0;
+    uintptr_t areaNameStrIdAddr_ = 0;
+};

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -19,6 +19,7 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/brushes.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/event_flags.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/game_items.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/saveman.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/slotconfig.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ui/loginwindow.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ui/notificationwindow.cpp

--- a/src/okami-apclient/ui/loginwindow.cpp
+++ b/src/okami-apclient/ui/loginwindow.cpp
@@ -9,6 +9,7 @@
 #include <wolf_framework.hpp>
 
 #include "../isocket.h"
+#include "../saveman.h"
 #include "version.h"
 
 #ifdef _WIN32
@@ -18,7 +19,11 @@
 // Static state
 static std::string WindowName = "Archipelago Client " + std::string(version::string);
 static ISocket *g_socket = nullptr;
+static SaveMan *g_saveMan = nullptr;
 static bool g_visible = true;
+
+// AP save control state (reset on disconnect)
+static bool g_saveChoiceMade = false;
 
 // Connection form data (kept as char arrays for ImGui)
 static char g_server[128] = "archipelago.gg:38281";
@@ -52,6 +57,12 @@ void initialize(ISocket &socket)
 void shutdown()
 {
     g_socket = nullptr;
+    g_saveMan = nullptr;
+}
+
+void setSaveMan(SaveMan *saveMan)
+{
+    g_saveMan = saveMan;
 }
 
 bool isVisible()
@@ -163,6 +174,58 @@ static void renderConnectionForm()
         if (ImGui::Button("Disconnect"))
         {
             g_socket->disconnect();
+            g_saveChoiceMade = false;
+        }
+
+        // AP save controls (only relevant on title screen, not during gameplay)
+        if (g_saveMan && !g_saveMan->isApModeActive())
+        {
+            ImGui::Separator();
+
+            if (g_saveMan->hasSaveFile())
+            {
+                ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.2f, 1.0f), "AP save found for this slot.");
+
+                // Snapshot so BeginDisabled/EndDisabled stay paired within this frame
+                bool choiceMade = g_saveChoiceMade;
+
+                if (choiceMade)
+                {
+                    ImGui::BeginDisabled();
+                }
+
+                if (ImGui::Button("Continue AP Game"))
+                {
+                    g_saveMan->setPendingLoad(true);
+                    g_saveChoiceMade = true;
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("New AP Game"))
+                {
+                    g_saveMan->deleteSave();
+                    g_saveChoiceMade = true;
+                }
+
+                if (choiceMade)
+                {
+                    ImGui::EndDisabled();
+
+                    if (g_saveMan->isPendingLoad())
+                    {
+                        ImGui::TextColored(ImVec4(0.5f, 1.0f, 0.5f, 1.0f),
+                                           "Select Load Game from the title screen.");
+                    }
+                    else
+                    {
+                        ImGui::TextColored(ImVec4(0.5f, 1.0f, 0.5f, 1.0f),
+                                           "Select New Game from the title screen.");
+                    }
+                }
+            }
+            else
+            {
+                ImGui::Text("Start a new game to begin.");
+            }
         }
     }
 #endif

--- a/src/okami-apclient/ui/loginwindow.h
+++ b/src/okami-apclient/ui/loginwindow.h
@@ -5,6 +5,7 @@
 #endif
 
 class ISocket;
+class SaveMan;
 
 namespace loginwindow
 {
@@ -43,6 +44,13 @@ void setVisible(bool visible);
  * @brief Toggle login window visibility
  */
 void toggle();
+
+/**
+ * @brief Set the SaveMan instance for AP save controls
+ *
+ * When set and connected, the login window shows Continue/New Game buttons.
+ */
+void setSaveMan(SaveMan *saveMan);
 
 /**
  * @brief Get server connection string

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ add_library(apclient-testable STATIC
     # Shop data
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/data/shopdata.cpp
 
+    # Save system
+    ${CMAKE_SOURCE_DIR}/src/okami-apclient/saveman.cpp
+
     # Other testable sources
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/gamestate_accessors.cpp
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/slotconfig.cpp
@@ -67,6 +70,7 @@ add_executable(apclient-tests
     test_itempatch.cpp
     test_resourcepkg.cpp
     test_customiconpkg.cpp
+    test_saveman.cpp
 )
 
 target_include_directories(apclient-tests PRIVATE

--- a/tests/mocks/wolf_framework.hpp
+++ b/tests/mocks/wolf_framework.hpp
@@ -200,13 +200,11 @@ template <typename T, typename U> inline bool hookFunction(const char *module, u
     return true;
 }
 
-// Mock module base - return pointer to mockMemory so offset reads work
-inline void *getModuleBase(const char *module)
+// Mock module base - return address of mockMemory so module + offset reads work
+inline uintptr_t getModuleBase(const char *module)
 {
     (void)module;
-    // Return pointer to start of mockMemory so module + offset reads work
-    // Ensure mockMemory has enough space for typical offset ranges
-    return mock::mockMemory.data();
+    return reinterpret_cast<uintptr_t>(mock::mockMemory.data());
 }
 
 // Mock writeMemory - no-op in tests, always succeeds

--- a/tests/test_saveman.cpp
+++ b/tests/test_saveman.cpp
@@ -1,0 +1,562 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+#include "mock_archipelagosocket.h"
+#include "saveman.h"
+#include "wolf_framework.hpp"
+
+#include <okami/offsets.hpp>
+#include <okami/savefile.hpp>
+
+// Highest memory offset used by SaveMan: CharacterStats at 0xB4DF90.
+// Reserve enough mock memory to cover all game state regions.
+static constexpr size_t kMockMemorySize = 0xB60000;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Set up a connected mock socket and initialized SaveMan.
+/// Returns the SaveMan. Caller must keep socket alive.
+static std::unique_ptr<SaveMan> makeSaveMan(mock::MockArchipelagoSocket &socket)
+{
+    socket.connect("localhost", "TestSlot", "");
+    socket.setConnected(true);
+
+    auto sm = std::make_unique<SaveMan>(socket);
+    sm->initialize();
+    return sm;
+}
+
+/// Remove the test save file if it exists.
+static void cleanupSaveFile(SaveMan &sm)
+{
+    std::string path = sm.getSavePath();
+    if (!path.empty())
+    {
+        std::filesystem::remove(path);
+        std::filesystem::remove(path + ".tmp");
+    }
+}
+
+// =============================================================================
+// Checksum tests
+// =============================================================================
+
+TEST_CASE("Checksum: zero-filled slot yields seed", "[saveman][checksum]")
+{
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+
+    uint64_t checksum = SaveMan::computeChecksum(slot);
+    CHECK(checksum == 0x9be6fa3b72afda1d);
+}
+
+TEST_CASE("Checksum: header magic changes result", "[saveman][checksum]")
+{
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+
+    uint64_t zeroChecksum = SaveMan::computeChecksum(slot);
+
+    slot.header = 0x40400000;
+    uint64_t headerChecksum = SaveMan::computeChecksum(slot);
+
+    CHECK(headerChecksum != zeroChecksum);
+    // XOR property: result = seed ^ data[0], so the difference is exactly the header value
+    CHECK((zeroChecksum ^ headerChecksum) == 0x0000000040400000ULL);
+}
+
+TEST_CASE("Checksum: modifying checksum field does not change result", "[saveman][checksum]")
+{
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+    slot.header = 0x40400000;
+
+    uint64_t cs1 = SaveMan::computeChecksum(slot);
+
+    slot.checksum = 0xDEADBEEFCAFEBABEULL;
+    uint64_t cs2 = SaveMan::computeChecksum(slot);
+
+    CHECK(cs1 == cs2);
+}
+
+TEST_CASE("Checksum: deterministic — same data always yields same result", "[saveman][checksum]")
+{
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+    slot.header = 0x40400000;
+    slot.areaNameStrId = 42;
+    slot.timeRTC = 12345678ULL;
+
+    uint64_t cs1 = SaveMan::computeChecksum(slot);
+    uint64_t cs2 = SaveMan::computeChecksum(slot);
+    CHECK(cs1 == cs2);
+}
+
+TEST_CASE("Checksum: modifying any data region changes result", "[saveman][checksum]")
+{
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+    uint64_t baseline = SaveMan::computeChecksum(slot);
+
+    SECTION("character data")
+    {
+        slot.character.currentHealth = 100;
+        CHECK(SaveMan::computeChecksum(slot) != baseline);
+    }
+
+    SECTION("tracked data")
+    {
+        slot.tracked.timePlayed = 9999;
+        CHECK(SaveMan::computeChecksum(slot) != baseline);
+    }
+
+    SECTION("collection data")
+    {
+        slot.collection.currentMoney = 50000;
+        CHECK(SaveMan::computeChecksum(slot) != baseline);
+    }
+
+    SECTION("timeRTC")
+    {
+        slot.timeRTC = 1;
+        CHECK(SaveMan::computeChecksum(slot) != baseline);
+    }
+
+    SECTION("areaNameStrId via header qword")
+    {
+        slot.areaNameStrId = 7;
+        CHECK(SaveMan::computeChecksum(slot) != baseline);
+    }
+}
+
+TEST_CASE("Checksum: XOR self-inverse property", "[saveman][checksum]")
+{
+    // XOR is self-inverse: applying the same change twice returns to original
+    okami::SaveSlot slot;
+    std::memset(&slot, 0, sizeof(slot));
+    uint64_t original = SaveMan::computeChecksum(slot);
+
+    slot.character.maxHealth = 999;
+    uint64_t modified = SaveMan::computeChecksum(slot);
+    CHECK(modified != original);
+
+    slot.character.maxHealth = 0;
+    uint64_t restored = SaveMan::computeChecksum(slot);
+    CHECK(restored == original);
+}
+
+// =============================================================================
+// File I/O roundtrip tests
+// =============================================================================
+
+TEST_CASE("File I/O: save then load produces identical game state", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    // Write known values into mock game memory
+    uintptr_t base = wolf::getModuleBase("main.dll");
+    auto *charStats = reinterpret_cast<okami::CharacterStats *>(base + okami::main::characterStats);
+    charStats->currentHealth = 200;
+    charStats->maxHealth = 300;
+    charStats->currentPraise = 1500;
+    charStats->mainWeapon = 0x02;
+
+    auto *collection = reinterpret_cast<okami::CollectionData *>(base + okami::main::collectionData);
+    collection->currentMoney = 99999;
+    collection->numSaves = 7;
+
+    auto *tracker = reinterpret_cast<okami::TrackerData *>(base + okami::main::trackerData);
+    tracker->timePlayed = 54321;
+    tracker->gameOverCount = 3;
+
+    // Save
+    REQUIRE(sm->saveGameState());
+
+    // Verify file exists
+    std::string savePath = sm->getSavePath();
+    REQUIRE(std::filesystem::exists(savePath));
+    CHECK(std::filesystem::file_size(savePath) == sizeof(okami::SaveSlot));
+
+    // Corrupt game memory
+    charStats->currentHealth = 0;
+    charStats->maxHealth = 0;
+    collection->currentMoney = 0;
+    tracker->timePlayed = 0;
+
+    // Load
+    REQUIRE(sm->loadGameState());
+
+    // Verify restored
+    CHECK(charStats->currentHealth == 200);
+    CHECK(charStats->maxHealth == 300);
+    CHECK(charStats->currentPraise == 1500);
+    CHECK(charStats->mainWeapon == 0x02);
+    CHECK(collection->currentMoney == 99999);
+    CHECK(collection->numSaves == 7);
+    CHECK(tracker->timePlayed == 54321);
+    CHECK(tracker->gameOverCount == 3);
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+TEST_CASE("File I/O: hasSaveFile reflects file existence", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    cleanupSaveFile(*sm);
+    CHECK_FALSE(sm->hasSaveFile());
+
+    REQUIRE(sm->saveGameState());
+    CHECK(sm->hasSaveFile());
+
+    REQUIRE(sm->deleteSave());
+    CHECK_FALSE(sm->hasSaveFile());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("File I/O: load from non-existent file fails gracefully", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    cleanupSaveFile(*sm);
+    CHECK_FALSE(sm->loadGameState());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("File I/O: load from wrong-sized file fails", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    // Create a file with wrong size
+    std::string path = sm->getSavePath();
+    REQUIRE(!path.empty());
+    std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+    {
+        std::ofstream f(path, std::ios::binary);
+        char junk[64] = {};
+        f.write(junk, sizeof(junk));
+    }
+
+    CHECK_FALSE(sm->loadGameState());
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+TEST_CASE("File I/O: saved file contains valid checksum", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    // Write some data
+    uintptr_t base = wolf::getModuleBase("main.dll");
+    auto *charStats = reinterpret_cast<okami::CharacterStats *>(base + okami::main::characterStats);
+    charStats->currentHealth = 42;
+
+    REQUIRE(sm->saveGameState());
+
+    // Read the file directly and verify checksum
+    okami::SaveSlot slot;
+    std::string path = sm->getSavePath();
+    std::ifstream f(path, std::ios::binary);
+    REQUIRE(f.is_open());
+    f.read(reinterpret_cast<char *>(&slot), sizeof(slot));
+    f.close();
+
+    uint64_t computed = SaveMan::computeChecksum(slot);
+    CHECK(slot.checksum == computed);
+
+    // Also verify the header magic was written
+    CHECK(slot.header == 0x40400000);
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+// =============================================================================
+// AP mode lifecycle tests
+// =============================================================================
+
+TEST_CASE("AP mode: starts inactive", "[saveman][lifecycle]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+
+    CHECK_FALSE(sm->isApModeActive());
+    wolf::mock::reset();
+}
+
+TEST_CASE("AP mode: setApModeActive toggles state", "[saveman][lifecycle]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+
+    sm->setApModeActive(true);
+    CHECK(sm->isApModeActive());
+
+    sm->setApModeActive(false);
+    CHECK_FALSE(sm->isApModeActive());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("AP mode: getSavePath empty when disconnected", "[saveman][lifecycle]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    // Don't connect
+    SaveMan sm(socket);
+    sm.initialize();
+
+    CHECK(sm.getSavePath().empty());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("AP mode: save fails when not initialized", "[saveman][lifecycle]")
+{
+    mock::MockArchipelagoSocket socket;
+    socket.connect("localhost", "TestSlot", "");
+    socket.setConnected(true);
+
+    SaveMan sm(socket);
+    // Don't call initialize()
+
+    CHECK_FALSE(sm.saveGameState());
+    CHECK_FALSE(sm.loadGameState());
+}
+
+// =============================================================================
+// Auto-save debounce tests
+// =============================================================================
+
+TEST_CASE("Auto-save: does not trigger when AP mode inactive", "[saveman][autosave]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    // AP mode is off by default
+
+    cleanupSaveFile(*sm);
+
+    sm->queueAutoSave();
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    sm->processAutoSave();
+
+    // Should not have saved because AP mode is inactive
+    CHECK_FALSE(sm->hasSaveFile());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("Auto-save: triggers after debounce period", "[saveman][autosave]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    cleanupSaveFile(*sm);
+
+    sm->queueAutoSave();
+
+    // Immediately: should NOT fire (within debounce window)
+    sm->processAutoSave();
+    CHECK_FALSE(sm->hasSaveFile());
+
+    // After debounce period: should fire
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    sm->processAutoSave();
+    CHECK(sm->hasSaveFile());
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+TEST_CASE("Auto-save: rapid queues coalesce to single save", "[saveman][autosave]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    cleanupSaveFile(*sm);
+
+    // Queue many times rapidly
+    for (int i = 0; i < 10; i++)
+    {
+        sm->queueAutoSave();
+        sm->processAutoSave(); // Each call within debounce window — no save
+    }
+    CHECK_FALSE(sm->hasSaveFile());
+
+    // Wait for debounce then process
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    sm->processAutoSave();
+    CHECK(sm->hasSaveFile());
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+// =============================================================================
+// Snapshot/restore: verify all 6 memory regions survive roundtrip
+// =============================================================================
+
+TEST_CASE("Snapshot roundtrip: all 6 memory regions preserved", "[saveman][snapshot]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    uintptr_t base = wolf::getModuleBase("main.dll");
+
+    // Set distinctive values in each region
+    auto *charStats = reinterpret_cast<okami::CharacterStats *>(base + okami::main::characterStats);
+    charStats->currentHealth = 0xBEEF;
+    charStats->totalPraise = 0xCAFE;
+
+    auto *tracker = reinterpret_cast<okami::TrackerData *>(base + okami::main::trackerData);
+    tracker->timePlayed = 0xDEAD;
+
+    auto *collection = reinterpret_cast<okami::CollectionData *>(base + okami::main::collectionData);
+    collection->currentMoney = 0x1234;
+
+    auto *mapData = reinterpret_cast<okami::MapState *>(base + okami::main::mapData);
+    mapData[0].user[0] = 0xAAAA;
+    mapData[5].user[3] = 0xBBBB;
+
+    auto *dialogBits = reinterpret_cast<okami::BitField<512> *>(base + okami::main::dialogBits);
+    // Set a specific bit in the first map's dialog bits
+    auto *rawBits = reinterpret_cast<uint32_t *>(&dialogBits[0]);
+    rawBits[0] = 0x12345678;
+
+    auto *customTex = reinterpret_cast<okami::CustomTextures *>(base + okami::main::customTextures);
+    auto *texBytes = reinterpret_cast<uint8_t *>(customTex);
+    texBytes[0] = 0xAA;
+    texBytes[1] = 0xBB;
+
+    // Save
+    REQUIRE(sm->saveGameState());
+
+    // Zero all regions
+    std::memset(charStats, 0, sizeof(okami::CharacterStats));
+    std::memset(tracker, 0, sizeof(okami::TrackerData));
+    std::memset(collection, 0, sizeof(okami::CollectionData));
+    std::memset(mapData, 0, sizeof(okami::MapState) * okami::MapTypes::NUM_MAP_TYPES);
+    std::memset(dialogBits, 0, sizeof(okami::BitField<512>) * okami::MapTypes::NUM_MAP_TYPES);
+    std::memset(customTex, 0, sizeof(okami::CustomTextures));
+
+    // Load
+    REQUIRE(sm->loadGameState());
+
+    // Verify all regions restored
+    CHECK(charStats->currentHealth == 0xBEEF);
+    CHECK(charStats->totalPraise == 0xCAFE);
+    CHECK(tracker->timePlayed == 0xDEAD);
+    CHECK(collection->currentMoney == 0x1234);
+    CHECK(mapData[0].user[0] == 0xAAAA);
+    CHECK(mapData[5].user[3] == 0xBBBB);
+    CHECK(rawBits[0] == 0x12345678);
+    CHECK(texBytes[0] == 0xAA);
+    CHECK(texBytes[1] == 0xBB);
+
+    cleanupSaveFile(*sm);
+    wolf::mock::reset();
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+TEST_CASE("Different connections produce different save files", "[saveman][edge]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket1;
+    socket1.connect("server1", "Slot1", "");
+    socket1.setConnected(true);
+
+    mock::MockArchipelagoSocket socket2;
+    socket2.connect("server2", "Slot2", "");
+    socket2.setConnected(true);
+
+    SaveMan sm1(socket1);
+    sm1.initialize();
+    SaveMan sm2(socket2);
+    sm2.initialize();
+
+    CHECK(sm1.getSavePath() != sm2.getSavePath());
+
+    wolf::mock::reset();
+}
+
+TEST_CASE("deleteSave removes file", "[saveman][fileio]")
+{
+    wolf::mock::reset();
+    wolf::mock::reserveMemory(kMockMemorySize);
+
+    mock::MockArchipelagoSocket socket;
+    auto sm = makeSaveMan(socket);
+    sm->setApModeActive(true);
+
+    REQUIRE(sm->saveGameState());
+    REQUIRE(sm->hasSaveFile());
+
+    REQUIRE(sm->deleteSave());
+    CHECK_FALSE(sm->hasSaveFile());
+
+    wolf::mock::reset();
+}


### PR DESCRIPTION
## Changes
-  Adds SaveMan to manage saves
- Separate AP saves from vanilla Steam Cloud saves, as "<slot>_<seed>.oksav"
- Adds autosaves on check send to socket
- Fixes timing error on brushman init

Closes #86, #85
