### PR TITLE
Fix brushman never getting instantiated

### DIFF
--- a/src/okami-apclient/checkman.cpp
+++ b/src/okami-apclient/checkman.cpp
@@ -113,6 +113,14 @@ bool CheckMan::isSendingEnabled() const
 
 void CheckMan::poll()
 {
+    // Lazily create brush handler once slot config arrives (connection happens after init)
+    if (!brushHandler_ && socket_.isSlotConfigReady() && socket_.getSlotConfig().randomizeBrushes)
+    {
+        auto callback = [this](int64_t checkId) { sendCheck(checkId); };
+        brushHandler_ = std::make_unique<checks::BrushMan>(callback);
+        brushHandler_->initialize();
+    }
+
     if (containerHandler_)
     {
         containerHandler_->poll();

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -26,7 +26,7 @@ static std::unique_ptr<CheckMan> g_checkMan;
 // GUI window name for wolf registration
 static const char *g_guiWindowName = "APClient GUI";
 
-// Main GUI render function - calls all internal windows
+// Main GUI render function
 static void renderGui(int outerWidth, int outerHeight, [[maybe_unused]] float uiScale)
 {
 #ifdef _WIN32


### PR DESCRIPTION
Lazily create the brush check handler in CheckMan::poll once slot config is ready, instead of at initialize() time when the socket hasn't connected yet.