### PR TITLE
Fix #114: ship icon DDS files in releases and harden shop fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,12 @@ jobs:
           $stageDir = "release"
 
           New-Item -ItemType Directory -Force -Path "$stageDir/apclient"
+          New-Item -ItemType Directory -Force -Path "$stageDir/apclient/game-data/icons"
           Copy-Item "$buildDir/src/okami-apclient/okami-apclient.dll" "$stageDir/apclient/"
           Copy-Item "$buildDir/cacert.pem" "$stageDir/apclient/"
+          Copy-Item "src/okami-apclient/icons/ap_standard.dds" "$stageDir/apclient/game-data/icons/"
+          Copy-Item "src/okami-apclient/icons/ap_progression.dds" "$stageDir/apclient/game-data/icons/"
+          Copy-Item "src/okami-apclient/icons/ap_trap.dds" "$stageDir/apclient/game-data/icons/"
 
       - name: Create Release Archive
         run: |

--- a/include/okami/customiconpkg.hpp
+++ b/include/okami/customiconpkg.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <array>
+#include <expected>
 #include <filesystem>
 #include <span>
+#include <string>
 #include <string_view>
 
 #include "okami/itemtype.hpp"
@@ -58,12 +60,13 @@ inline constexpr std::string_view kPackageResourceName = "archipelago/customicon
 /// Build a combined package: all entries from the encrypted vanilla package at
 /// vanillaPath, followed by the custom DDS icons.  The combined package is written
 /// to outPath using the same Blowfish format.
-/// vanillaCount receives the number of vanilla entries (= 0-based index of the
-/// first custom entry in the combined package).
-/// Returns true on success; false if the vanilla package cannot be read or DDS
-/// files are missing.
-[[nodiscard]] bool buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath,
-                                          const std::filesystem::path &standardPath, const std::filesystem::path &progressionPath,
-                                          const std::filesystem::path &trapPath, int &vanillaCount);
+///
+/// Returns the number of vanilla entries on success (= 0-based index of the
+/// first custom entry in the combined package). On failure returns a string
+/// naming the specific input that couldn't be processed (vanilla DAT,
+/// individual DDS file, or output write), so the caller can log it.
+[[nodiscard]] std::expected<int, std::string>
+buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath, const std::filesystem::path &standardPath,
+                       const std::filesystem::path &progressionPath, const std::filesystem::path &trapPath);
 
 } // namespace okami::customiconpkg

--- a/src/okami-apclient/checks/shops.cpp
+++ b/src/okami-apclient/checks/shops.cpp
@@ -422,6 +422,49 @@ void ShopMan::scoutShopsForMap(uint16_t mapId)
     }
 }
 
+// When the combined icon package isn't available, AP-dummy item types have no
+// vanilla icon-table entry and rendering them crashes the game. Substitute a
+// vanilla item type that has an icon — chestnut (the same value we redirect
+// to in itempatch::hookBuildItemResourceName for the matching model crash).
+constexpr okami::ItemTypes::Enum kIconlessFallback = static_cast<okami::ItemTypes::Enum>(0x83);
+
+okami::ItemTypes::Enum selectShopItemType(const ScoutedItem &scouted, int mySlot, bool hasCustomIcons)
+{
+    auto isWeapon = [](int itemId) { return itemId >= okami::ItemTypes::DivineRetribution && itemId <= okami::ItemTypes::ThunderEdge; };
+
+    const bool isNative = !rewards::isForeignItem(scouted.player, mySlot);
+
+    // Native, directly displayable item: pass through. Independent of icon
+    // package state — this branch never produces a dummy type.
+    if (isNative && rewards::game_items::isDirectGameItem(scouted.item))
+    {
+        const int rawItem = rewards::game_items::getItemId(scouted.item);
+        if (!isWeapon(rawItem))
+            return static_cast<okami::ItemTypes::Enum>(rawItem);
+    }
+
+    // Everything else (foreign items, native progressive weapons, native
+    // brushes / event flags, native weapons that can't be shop-rendered) needs
+    // a dummy or fallback.
+    if (!hasCustomIcons)
+        return kIconlessFallback;
+
+    if (!isNative)
+    {
+        if (rewards::isTrap(scouted.flags))
+            return okami::ItemTypes::ForeignTrapItem;
+        if (rewards::isProgression(scouted.flags))
+            return okami::ItemTypes::ForeignProgressionItem;
+        return okami::ItemTypes::ForeignStandardItem;
+    }
+
+    if (rewards::isTrap(scouted.flags))
+        return okami::ItemTypes::OkamiTrapItem;
+    if (rewards::isProgression(scouted.flags))
+        return okami::ItemTypes::OkamiProgressionItem;
+    return okami::ItemTypes::OkamiStandardItem;
+}
+
 void ShopMan::populateShopFromScoutedData(int shopId)
 {
     wolf::logDebug("[ShopMan] populateShopFromScoutedData called for shopId=%d", shopId);
@@ -435,12 +478,14 @@ void ShopMan::populateShopFromScoutedData(int shopId)
 
     shop->ClearStock();
 
-    int slotCount = socket_.getSlotConfig().shopSlots;
-    wolf::logDebug("[ShopMan] Populating %d slots", slotCount);
+    const int slotCount = socket_.getSlotConfig().shopSlots;
+    const int mySlot = socket_.getPlayerSlot();
+    const bool hasCustomIcons = itempatch::hasCustomIcons();
+    wolf::logDebug("[ShopMan] Populating %d slots (hasCustomIcons=%d)", slotCount, hasCustomIcons ? 1 : 0);
 
     for (int slot = 0; slot < slotCount; ++slot)
     {
-        int64_t locationId = checks::getShopCheckId(shopId, slot);
+        const int64_t locationId = checks::getShopCheckId(shopId, slot);
         auto it = scoutedItems_.find(locationId);
         if (it == scoutedItems_.end())
         {
@@ -449,71 +494,22 @@ void ShopMan::populateShopFromScoutedData(int shopId)
         }
 
         const ScoutedItem &scouted = it->second;
+        const okami::ItemTypes::Enum gameItem = selectShopItemType(scouted, mySlot, hasCustomIcons);
 
-        // Convert AP item ID to game item
-        okami::ItemTypes::Enum gameItem;
-
-        // Helper to check if a game item is a weapon (divine instruments can't be displayed in shops)
-        auto isWeapon = [](int itemId) { return itemId >= okami::ItemTypes::DivineRetribution && itemId <= okami::ItemTypes::ThunderEdge; };
-
-        const int mySlot = socket_.getPlayerSlot();
-        const bool isNative = !rewards::isForeignItem(scouted.player, mySlot);
-
-        // Helper to select a native Okami dummy item based on AP classification flags
-        auto nativeDummy = [](unsigned flags)
-        {
-            if (rewards::isTrap(flags))
-                return okami::ItemTypes::OkamiTrapItem;
-            if (rewards::isProgression(flags))
-                return okami::ItemTypes::OkamiProgressionItem;
-            return okami::ItemTypes::OkamiStandardItem;
-        };
-
-        if (isNative && rewards::game_items::isDirectGameItem(scouted.item))
-        {
-            int rawItem = rewards::game_items::getItemId(scouted.item);
-            if (isWeapon(rawItem))
-            {
-                // Weapons can't be displayed in item shops - use dummy
-                gameItem = nativeDummy(scouted.flags);
-                itempatch::registerScoutedItemName(locationId, socket_.getItemName(scouted.item, socket_.getPlayerSlot()));
-                wolf::logDebug("[ShopMan] Slot %d: native AP item %lld -> weapon %d, using dummy %d", slot, scouted.item, rawItem, static_cast<int>(gameItem));
-            }
-            else
-            {
-                // Displayable native item — use raw type for vanilla icon and name
-                gameItem = static_cast<okami::ItemTypes::Enum>(rawItem);
-                wolf::logDebug("[ShopMan] Slot %d: native AP item %lld -> game item %d", slot, scouted.item, rawItem);
-            }
-        }
-        else if (isNative && rewards::game_items::isProgressiveWeapon(scouted.item))
-        {
-            // Progressive weapons always need dummy in shops
-            gameItem = nativeDummy(scouted.flags);
-            itempatch::registerScoutedItemName(locationId, socket_.getItemName(scouted.item, socket_.getPlayerSlot()));
-            wolf::logDebug("[ShopMan] Slot %d: native AP item %lld -> progressive weapon, using dummy %d", slot, scouted.item, static_cast<int>(gameItem));
-        }
-        else if (isNative)
-        {
-            // Native brushes, event flags, etc.
-            gameItem = nativeDummy(scouted.flags);
-            itempatch::registerScoutedItemName(locationId, socket_.getItemName(scouted.item, socket_.getPlayerSlot()));
-            wolf::logDebug("[ShopMan] Slot %d: native AP item %lld -> non-game item, using dummy %d (flags=0x%x)", slot, scouted.item,
-                           static_cast<int>(gameItem), scouted.flags);
-        }
-        else
-        {
-            // Foreign item — select AP dummy type based on classification flags
-            if (rewards::isTrap(scouted.flags))
-                gameItem = okami::ItemTypes::ForeignTrapItem;
-            else if (rewards::isProgression(scouted.flags))
-                gameItem = okami::ItemTypes::ForeignProgressionItem;
-            else
-                gameItem = okami::ItemTypes::ForeignStandardItem;
+        // Register the scouted name keyed by location so the MSD hook can
+        // resolve it when a dummy type is rendered. Skipped when we passed
+        // the native item type through directly (display name is correct
+        // already) and when we substituted the icon-less fallback (the
+        // fallback type isn't a dummy strId, so the lookup wouldn't fire
+        // anyway).
+        const bool isDummy = gameItem == okami::ItemTypes::ForeignStandardItem || gameItem == okami::ItemTypes::ForeignProgressionItem ||
+                             gameItem == okami::ItemTypes::ForeignTrapItem || gameItem == okami::ItemTypes::OkamiStandardItem ||
+                             gameItem == okami::ItemTypes::OkamiProgressionItem || gameItem == okami::ItemTypes::OkamiTrapItem;
+        if (isDummy)
             itempatch::registerScoutedItemName(locationId, socket_.getItemName(scouted.item, scouted.player));
-            wolf::logDebug("[ShopMan] Slot %d: foreign AP item %lld -> dummy type %d (flags=0x%x)", slot, scouted.item, static_cast<int>(gameItem),
-                           scouted.flags);
-        }
+
+        wolf::logDebug("[ShopMan] Slot %d: AP item %lld (player %d, flags 0x%x) -> game item %d", slot, scouted.item, scouted.player, scouted.flags,
+                       static_cast<int>(gameItem));
 
         // TODO: Get actual price from AP data or slot_data
         constexpr int32_t placeholderCost = 100;

--- a/src/okami-apclient/checks/shops.hpp
+++ b/src/okami-apclient/checks/shops.hpp
@@ -65,6 +65,17 @@ okami::ItemShopStock *GetCurrentDemonFangShopData(uint16_t mapId, uint32_t *pNum
     return MaxShopStockSize;
 }
 
+/// Decide which game item type a shop slot should display for a scouted AP item.
+///
+/// When `hasCustomIcons` is true, foreign items and non-displayable native items
+/// resolve to AP-dummy item types (Foreign{Standard,Progression,Trap}Item etc.)
+/// so the icon-package hook can render the AP icon and the MSD hook can swap
+/// in the scouted name. When `hasCustomIcons` is false (combined icon package
+/// failed to build), those same dummy types would walk off the vanilla icon
+/// table and crash the game on render — substitute a vanilla item so the slot
+/// is still purchasable.
+[[nodiscard]] okami::ItemTypes::Enum selectShopItemType(const ScoutedItem &scouted, int mySlot, bool hasCustomIcons);
+
 /**
  * @brief Manager for shop randomization and purchase detection
  *

--- a/src/okami-apclient/data/customiconpkg.cpp
+++ b/src/okami-apclient/data/customiconpkg.cpp
@@ -108,15 +108,14 @@ bool buildFromFiles(const std::filesystem::path &outPath, const std::filesystem:
     return build(outPath, std_data, prog_data, trap_data);
 }
 
-bool buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath, const std::filesystem::path &standardPath,
-                            const std::filesystem::path &progressionPath, const std::filesystem::path &trapPath, int &vanillaCount)
+std::expected<int, std::string> buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath,
+                                                       const std::filesystem::path &standardPath, const std::filesystem::path &progressionPath,
+                                                       const std::filesystem::path &trapPath)
 {
-    vanillaCount = 0;
-
     const auto vanillaEntries = readPackageEntries(vanillaPath);
     if (vanillaEntries.empty())
-        return false;
-    vanillaCount = static_cast<int>(vanillaEntries.size());
+        return std::unexpected("vanilla package missing or unreadable: " + vanillaPath.string());
+    const int vanillaCount = static_cast<int>(vanillaEntries.size());
 
     auto readFile = [](const std::filesystem::path &p) -> std::vector<uint8_t>
     {
@@ -127,11 +126,14 @@ bool buildCombinedFromFiles(const std::filesystem::path &outPath, const std::fil
     };
 
     const auto std_data = readFile(standardPath);
+    if (std_data.empty())
+        return std::unexpected("standard icon DDS missing or empty: " + standardPath.string());
     const auto prog_data = readFile(progressionPath);
+    if (prog_data.empty())
+        return std::unexpected("progression icon DDS missing or empty: " + progressionPath.string());
     const auto trap_data = readFile(trapPath);
-
-    if (std_data.empty() || prog_data.empty() || trap_data.empty())
-        return false;
+    if (trap_data.empty())
+        return std::unexpected("trap icon DDS missing or empty: " + trapPath.string());
 
     const std::array<std::span<const uint8_t>, 3> ddsBuffers = {std_data, prog_data, trap_data};
 
@@ -145,7 +147,9 @@ bool buildCombinedFromFiles(const std::filesystem::path &outPath, const std::fil
     for (const auto &e : kIconEntries)
         pkg.addEntry(ResourceType{'D', 'D', 'S', '\0'}, ddsBuffers[static_cast<size_t>(e.ddsIndex)]);
 
-    return pkg.write(outPath);
+    if (!pkg.write(outPath))
+        return std::unexpected("output write failed: " + outPath.string());
+    return vanillaCount;
 }
 
 } // namespace okami::customiconpkg

--- a/src/okami-apclient/itempatch.cpp
+++ b/src/okami-apclient/itempatch.cpp
@@ -334,6 +334,16 @@ void resetState()
     clearContainerContext();
 }
 
+bool hasCustomIcons()
+{
+    return s_customIconBase >= 0;
+}
+
+void setHasCustomIconsForTests(bool present)
+{
+    s_customIconBase = present ? 1 : -1;
+}
+
 void registerScoutedItemName(int64_t locationId, const std::string &name)
 {
     if (s_nextCustomIndex >= INT16_MAX)
@@ -369,17 +379,18 @@ void initializeEarly()
     if (!std::filesystem::exists(vanillaPath))
         vanillaPath = std::filesystem::current_path() / "data_pc" / "id" / "ItemShopBuyIcon.dat";
 
-    int vanillaCount = 0;
-    if (okami::customiconpkg::buildCombinedFromFiles(cwdPkgPath, vanillaPath, standardPath, progressionPath, trapPath, vanillaCount))
+    auto buildResult = okami::customiconpkg::buildCombinedFromFiles(cwdPkgPath, vanillaPath, standardPath, progressionPath, trapPath);
+    if (buildResult)
     {
-        s_customIconBase = vanillaCount + 1; // +1: s_loadRscIdx is 1-based
-        wolf::logInfo("[itempatch] Combined icon package built: %s (vanilla: %d, custom: %zu)", cwdPkgPath.string().c_str(), vanillaCount,
+        s_customIconBase = *buildResult + 1; // +1: s_loadRscIdx is 1-based
+        wolf::logInfo("[itempatch] Combined icon package built: %s (vanilla: %d, custom: %zu)", cwdPkgPath.string().c_str(), *buildResult,
                       okami::customiconpkg::kIconEntries.size());
     }
     else
     {
-        wolf::logError("[itempatch] Failed to build combined icon package. Vanilla: %s, Icons: %s", vanillaPath.string().c_str(),
-                       (modDir / "game-data/icons/").string().c_str());
+        // Shop slots backed by AP-dummy item types will fall back to a vanilla
+        // item to avoid the icon-table OOB crash; see ShopMan::populateShopFromScoutedData.
+        wolf::logError("[itempatch] Failed to build combined icon package: %s", buildResult.error().c_str());
     }
 
     // GetNumEntries must be hooked before flower_startup runs the texture

--- a/src/okami-apclient/itempatch.hpp
+++ b/src/okami-apclient/itempatch.hpp
@@ -53,4 +53,16 @@ void clearContainerContext();
 /// Reset all dynamic state (custom strings, location index, shop context).
 /// For use in tests to prevent cross-test pollution.
 void resetState();
+
+/// True iff the combined icon package was successfully built during
+/// initializeEarly() — i.e. the game can render AP-dummy item types.
+/// Callers should substitute a vanilla item type (e.g. chestnut) when this
+/// returns false, otherwise the game's icon lookup walks off-table and
+/// crashes when the slot is rendered.
+bool hasCustomIcons();
+
+/// Test-only: override the cached icon-package state without re-running
+/// initializeEarly(). Used by ShopMan tests to exercise the
+/// "icons-failed-to-build" fallback branch.
+void setHasCustomIconsForTests(bool present);
 } // namespace itempatch

--- a/tests/test_shops.cpp
+++ b/tests/test_shops.cpp
@@ -9,7 +9,9 @@
 
 #include "checks/check_types.hpp"
 #include "checks/shops.hpp"
+#include "isocket.h"
 #include "mock_archipelagosocket.h"
+#include "rewards/reward_types.hpp"
 #include "wolf_framework.hpp"
 
 // ============================================================================
@@ -437,4 +439,83 @@ TEST_CASE_METHOD(ShopManFixture, "ShopMan shutdown clears active instance", "[sh
     shopMan_->shutdown();
 
     TearDown();
+}
+
+// ============================================================================
+// selectShopItemType: shop slot item-type substitution
+//
+// When the combined icon package is built, foreign / non-displayable items
+// resolve to AP-dummy item types so the icon hook can render the AP icon and
+// the MSD hook can swap in the scouted name. When the icon package is missing,
+// those same dummy types crash the game on render, so the slot must fall back
+// to a vanilla item type that the game already has an icon for.
+// ============================================================================
+
+namespace
+{
+constexpr unsigned kProgressionFlag = static_cast<unsigned>(rewards::APItemFlags::Progression);
+constexpr unsigned kTrapFlag = static_cast<unsigned>(rewards::APItemFlags::Trap);
+constexpr int kMyPlayer = 1;
+constexpr int kOtherPlayer = 2;
+
+ScoutedItem makeScouted(int64_t apItemId, int destinationPlayer, unsigned flags)
+{
+    return ScoutedItem{.item = apItemId, .location = 300000, .player = destinationPlayer, .flags = flags};
+}
+} // namespace
+
+TEST_CASE("selectShopItemType: native displayable item passes through unchanged", "[shops][selectShopItemType]")
+{
+    // A regular Okami item destined for the local player should always show
+    // its real type — independent of icon-package state.
+    const auto scouted = makeScouted(/*ginseng=*/0x39, kMyPlayer, 0);
+
+    CHECK(checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/true) == 0x39);
+    CHECK(checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/false) == 0x39);
+}
+
+TEST_CASE("selectShopItemType: foreign item uses dummy when icons available", "[shops][selectShopItemType]")
+{
+    const auto scouted = makeScouted(/*arbitrary=*/12345, kOtherPlayer, kProgressionFlag);
+
+    CHECK(checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/true) == okami::ItemTypes::ForeignProgressionItem);
+}
+
+TEST_CASE("selectShopItemType: foreign item falls back to vanilla item when icons missing", "[shops][selectShopItemType]")
+{
+    // Without the combined icon package, the foreign-progression dummy type
+    // (0x82) has no entry in the vanilla icon table; rendering it crashes the
+    // game. Expect a vanilla item type instead — anything in the regular
+    // 0x00..0xFF range that has a vanilla icon. Chestnut (0x83) is the value
+    // we already redirect to in BuildItemResourceName for the same reason.
+    const auto scouted = makeScouted(12345, kOtherPlayer, kProgressionFlag);
+
+    auto result = checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/false);
+    CHECK(result != okami::ItemTypes::ForeignProgressionItem);
+    CHECK(result != okami::ItemTypes::ForeignStandardItem);
+    CHECK(result != okami::ItemTypes::ForeignTrapItem);
+    CHECK(result != okami::ItemTypes::OkamiProgressionItem);
+    CHECK(result != okami::ItemTypes::OkamiStandardItem);
+    CHECK(result != okami::ItemTypes::OkamiTrapItem);
+}
+
+TEST_CASE("selectShopItemType: native non-displayable (brush) falls back without icons", "[shops][selectShopItemType]")
+{
+    // AP-side native progression items that aren't directly displayable (a
+    // brush AP item id, here 0x10C / Power Slash, is in the brush range —
+    // not a vanilla shop-renderable item).
+    const auto scouted = makeScouted(/*power_slash=*/0x10C, kMyPlayer, kProgressionFlag);
+
+    CHECK(checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/true) == okami::ItemTypes::OkamiProgressionItem);
+
+    auto fallback = checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/false);
+    CHECK(fallback != okami::ItemTypes::OkamiProgressionItem);
+    CHECK(fallback != okami::ItemTypes::OkamiStandardItem);
+    CHECK(fallback != okami::ItemTypes::OkamiTrapItem);
+}
+
+TEST_CASE("selectShopItemType: trap classification preserved when icons available", "[shops][selectShopItemType]")
+{
+    const auto scouted = makeScouted(12345, kOtherPlayer, kTrapFlag);
+    CHECK(checks::selectShopItemType(scouted, kMyPlayer, /*hasCustomIcons=*/true) == okami::ItemTypes::ForeignTrapItem);
 }


### PR DESCRIPTION
Two compounding bugs:

  1. Release packaging never shipped the icon DDS files. The CMake install rule places them at apclient/game-data/icons/, but .github/workflows/release.yml's stage step only grabbed okami-apclient.dll and cacert.pem.
  2. ShopMan still placed AP-dummy item types into slots even when the icon package was missing. The vanilla icon table has no entries for ForeignProgressionItem (0x82) etc. when the game tried to render the slot it walked off the table and crashed.

## Changes
- stage src/okami-apclient/icons/ap_{standard,progression,trap}.dds into apclient/game-data/icons/ alongside the DLL.
- customiconpkg::buildCombinedFromFiles: now returns std::expected<int, std::string> and names the specific input that failed (vanilla DAT / each DDS / output write).
- itempatch::hasCustomIcons(): query for whether the combined package was built.
- ShopMan::populateShopFromScoutedData: extract the slot item-type selection into a pure free function checks::selectShopItemType(scouted, mySlot, hasCustomIcons). When hasCustomIcons is false, foreign / non-displayable items fall back to chestnut (0x83)