### PR TITLE
Fix  MSD  bleed-through  into cutscenes and   shop  list  flicker

### DIFF
--- a/src/okami-apclient/itempatch.cpp
+++ b/src/okami-apclient/itempatch.cpp
@@ -289,13 +289,12 @@ static const uint16_t *__fastcall hookGetMSDString(void *pBase, uint16_t index)
         return s_origGetMSDString(pBase, remapped);
     }
 
-    // Virtual string table (for other possible uses)
-    if (index >= static_cast<uint16_t>(kCustomStringBase))
-    {
-        auto it = s_customStrings.find(static_cast<int16_t>(index));
-        if (it != s_customStrings.end())
-            return it->second.data();
-    }
+    // No more intercepts: every other path -- cutscene area banners, brush
+    // textboxes, the bottom-of-screen dialog system, etc. -- must pass through
+    // unchanged. (We previously kept a fallback here that looked up indices
+    // >= kCustomStringBase in s_customStrings, but the game allocates strIds
+    // throughout the 0x1000+ range and would silently match our virtual
+    // indices, replacing area names with item names. See issue #113.)
     return s_origGetMSDString(pBase, index);
 }
 
@@ -390,6 +389,11 @@ void resetState()
 void setShopMenuActiveOverrideForTests(int state)
 {
     s_shopMenuActiveOverride = state < 0 ? -1 : (state ? 1 : 0);
+}
+
+void setOrigGetMSDStringForTests(GetMSDStringForTestsFn fn)
+{
+    s_origGetMSDString = reinterpret_cast<GetMSDStringFn>(fn);
 }
 
 bool hasCustomIcons()

--- a/src/okami-apclient/itempatch.cpp
+++ b/src/okami-apclient/itempatch.cpp
@@ -147,8 +147,16 @@ static hx::Texture *__fastcall hookGetItemIcon(okami::cItemShop *pShop, int item
     return s_origGetItemIcon(pShop, item);
 }
 
-constexpr uint16_t kInfoPanelBase = 294;
-constexpr uint16_t kShopListBase = 0x2000;
+// Ground truth from in-game testing (see issue #124 reproduction screenshots):
+//   * The shop's row LIST queries `294 + itemType` -- the standard item-name
+//     base. Every visible row of the same dummy type shares one strId, so a
+//     slot-keyed substitution there would make every row of a type render as
+//     the currently-selected slot's name and flicker on cursor movement.
+//   * The shop's bottom INFO PANEL queries `0x2000 + itemType`. Only one item
+//     is shown there at a time (the selected slot), so resolving to the
+//     selected slot's scouted name is safe and unambiguous.
+constexpr uint16_t kListBase = 294;
+constexpr uint16_t kInfoPanelBase = 0x2000;
 
 constexpr auto kDummyTypes = std::to_array<uint16_t>({
     okami::ItemTypes::ForeignStandardItem,
@@ -159,27 +167,27 @@ constexpr auto kDummyTypes = std::to_array<uint16_t>({
     okami::ItemTypes::OkamiTrapItem,
 });
 
-/// True for an AP dummy item's info-panel strId (itemType + 294). The shop
-/// renders the selected item's detailed name from this strId, so it's safe
-/// to substitute the scouted name here.
+/// True for an AP dummy item's info-panel strId (itemType + 0x2000). Only the
+/// selected slot's item is rendered through this strId, so it's safe to
+/// substitute the scouted name here.
 static constexpr bool isApDummyInfoPanelStrId(uint16_t index)
 {
     return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kInfoPanelBase; });
 }
 
-/// True for an AP dummy item's shop-list strId (itemType + 0x2000). Multiple
-/// list rows share the same strId per type, so a slot-keyed lookup would make
-/// every visible row render as the currently-selected slot's name (issue #124).
-static constexpr bool isApDummyShopListStrId(uint16_t index)
+/// True for an AP dummy item's shop-list strId (itemType + 294). Multiple list
+/// rows share the same strId per type, so a slot-keyed lookup would make every
+/// visible row render as the currently-selected slot's name (issue #124).
+static constexpr bool isApDummyListStrId(uint16_t index)
 {
-    return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kShopListBase; });
+    return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kListBase; });
 }
 
 /// True for either path. Used by the container floating-name path, where the
 /// strId may come through either channel and there is only one item visible.
 static constexpr bool isApDummyAnyStrId(uint16_t index)
 {
-    return isApDummyInfoPanelStrId(index) || isApDummyShopListStrId(index);
+    return isApDummyInfoPanelStrId(index) || isApDummyListStrId(index);
 }
 
 static void __fastcall hookLoadCore20MSD(void *pMsgStruct)
@@ -239,11 +247,12 @@ const uint16_t *resolveApItemName(uint16_t strId)
     // Shop path: only resolve while the player is actually looking at a shop
     // menu. Without this gate, stale shop context bleeds the scouted name into
     // cutscene area titles, brush textboxes, etc. (issue #113). And only the
-    // info-panel strId resolves to the selected slot - the shop-list strId is
-    // shared across every visible row, so resolving by selected slot would make
-    // all row names flicker as the cursor moves (issue #124). The shop list
-    // falls through to the kShopListBase->kInfoPanelBase remap in
-    // hookGetMSDString, which yields the dummy type's generic name.
+    // info-panel strId (0x2000+) resolves to the selected slot -- the list
+    // strId (294+) is shared across every visible row of the same dummy type,
+    // so resolving by selected slot would make all those row names flicker as
+    // the cursor moves between them (issue #124). The list path falls through
+    // to the override we set during hookLoadCore20MSD, which yields the dummy
+    // type's generic name ("Archipelago Item", "Okami Progression", etc.).
     if (s_currentShopId >= 0 && s_pCurrentShop && isShopMenuActive() && isApDummyInfoPanelStrId(strId))
     {
         // Offsets validated against decompiled FUN_18043ca30 (cItemShop::PurchaseItem)
@@ -267,16 +276,16 @@ static const uint16_t *__fastcall hookGetMSDString(void *pBase, uint16_t index)
     if (apResult)
         return apResult;
 
-    // Shop list strIds use itemType + 0x2000, but our MSD overrides are at
-    // itemType + 294 (info panel path). Remap so items that don't normally
-    // appear in shops (HourglassOrb, Yen, Praise, dummy types, etc.) resolve
-    // to the same name we patched into the info panel path. Gated by the live
-    // "Item shop menu" GlobalGameState bit so the remap doesn't fire in
+    // The shop's bottom info-panel queries `0x2000 + itemType`, but items not
+    // normally sold in shops (HourglassOrb, Yen, Praise, our dummy types, etc.)
+    // have no entry at that strId. Fall back to the standard item-name strId
+    // (294 + itemType) where our hookLoadCore20MSD overrides live. Gated by the
+    // live "Item shop menu" GlobalGameState bit so the remap doesn't fire in
     // cutscenes, where strIds in the 0x2000+ range may belong to unrelated
     // dialog and would otherwise be silently rewritten (issue #113).
-    if (isShopMenuActive() && index >= kShopListBase && index < kShopListBase + okami::ItemTypes::NUM_ITEM_TYPES)
+    if (isShopMenuActive() && index >= kInfoPanelBase && index < kInfoPanelBase + okami::ItemTypes::NUM_ITEM_TYPES)
     {
-        uint16_t remapped = static_cast<uint16_t>((index - kShopListBase) + kInfoPanelBase);
+        uint16_t remapped = static_cast<uint16_t>((index - kInfoPanelBase) + kListBase);
         return s_origGetMSDString(pBase, remapped);
     }
 

--- a/src/okami-apclient/itempatch.cpp
+++ b/src/okami-apclient/itempatch.cpp
@@ -10,8 +10,10 @@
 
 #include <okami/msd.h>
 
+#include <okami/bitfield.hpp>
 #include <okami/customiconpkg.hpp>
 #include <okami/custommodelpkg.hpp>
+#include <okami/offsets.hpp>
 #include <okami/structs.hpp>
 #include <wolf_framework.hpp>
 
@@ -65,6 +67,27 @@ static int16_t s_nextCustomIndex = kCustomStringBase;
 static int s_currentShopId = -1;
 static int64_t s_currentContainerLocation = -1;
 static void *s_pCurrentShop = nullptr;
+
+// -1 = read live game state; 0/1 = forced for tests
+static int s_shopMenuActiveOverride = -1;
+
+constexpr unsigned kItemShopMenuBit = 10; // GlobalGameState bit; flips 0->1 on shop entry, 1->0 on exit
+
+/// Returns true when the game's "Item shop menu" GlobalGameState bit is set.
+/// MSD substitutions in resolveApItemName and hookGetMSDString must be gated
+/// by this so name swaps don't leak into cutscenes, dialog boxes, brush
+/// trigger overlays, or anywhere else outside the active shop UI.
+static bool isShopMenuActive()
+{
+    if (s_shopMenuActiveOverride >= 0)
+        return s_shopMenuActiveOverride != 0;
+
+    const auto mainBase = reinterpret_cast<uintptr_t>(wolf::getModuleBase("main.dll"));
+    if (!mainBase)
+        return false;
+    const auto *bits = reinterpret_cast<const okami::BitField<86> *>(mainBase + okami::main::globalGameStateFlags);
+    return bits->IsSet(kItemShopMenuBit);
+}
 
 /// Returns the directory containing apclient.dll at runtime.
 /// Falls back to "mods/apclient" (CWD-relative) on non-Windows builds.
@@ -124,24 +147,39 @@ static hx::Texture *__fastcall hookGetItemIcon(okami::cItemShop *pShop, int item
     return s_origGetItemIcon(pShop, item);
 }
 
-/// Returns true if the given MSD string index corresponds to an AP dummy item
-/// for both the shop list (itemType + 294) and info panel (itemType + 0x2000)
-/// paths. Both resolve to the selected slot's scouted name, so items sharing
-/// a dummy type will all show the selected item's name in the list. The info
-/// panel always shows the correct name since it displays the selected item.
-static constexpr bool isApDummyStrId(uint16_t index)
+constexpr uint16_t kInfoPanelBase = 294;
+constexpr uint16_t kShopListBase = 0x2000;
+
+constexpr auto kDummyTypes = std::to_array<uint16_t>({
+    okami::ItemTypes::ForeignStandardItem,
+    okami::ItemTypes::ForeignProgressionItem,
+    okami::ItemTypes::ForeignTrapItem,
+    okami::ItemTypes::OkamiStandardItem,
+    okami::ItemTypes::OkamiProgressionItem,
+    okami::ItemTypes::OkamiTrapItem,
+});
+
+/// True for an AP dummy item's info-panel strId (itemType + 294). The shop
+/// renders the selected item's detailed name from this strId, so it's safe
+/// to substitute the scouted name here.
+static constexpr bool isApDummyInfoPanelStrId(uint16_t index)
 {
-    constexpr uint16_t kListBase = 294;
-    constexpr uint16_t kInfoPanelBase = 0x2000;
-    constexpr auto kDummyTypes = std::to_array<uint16_t>({
-        okami::ItemTypes::ForeignStandardItem,
-        okami::ItemTypes::ForeignProgressionItem,
-        okami::ItemTypes::ForeignTrapItem,
-        okami::ItemTypes::OkamiStandardItem,
-        okami::ItemTypes::OkamiProgressionItem,
-        okami::ItemTypes::OkamiTrapItem,
-    });
-    return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kListBase || index == t + kInfoPanelBase; });
+    return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kInfoPanelBase; });
+}
+
+/// True for an AP dummy item's shop-list strId (itemType + 0x2000). Multiple
+/// list rows share the same strId per type, so a slot-keyed lookup would make
+/// every visible row render as the currently-selected slot's name (issue #124).
+static constexpr bool isApDummyShopListStrId(uint16_t index)
+{
+    return std::ranges::any_of(kDummyTypes, [&](uint16_t t) { return index == t + kShopListBase; });
+}
+
+/// True for either path. Used by the container floating-name path, where the
+/// strId may come through either channel and there is only one item visible.
+static constexpr bool isApDummyAnyStrId(uint16_t index)
+{
+    return isApDummyInfoPanelStrId(index) || isApDummyShopListStrId(index);
 }
 
 static void __fastcall hookLoadCore20MSD(void *pMsgStruct)
@@ -185,9 +223,9 @@ static void __fastcall hookLoadCore20MSD(void *pMsgStruct)
 
 const uint16_t *resolveApItemName(uint16_t strId)
 {
-    // Resolve container item names — when a container's floating item is displayed,
-    // s_currentContainerLocation is set to the location being shown.
-    if (s_currentContainerLocation >= 0 && isApDummyStrId(strId))
+    // Container path: only one floating item is visible at a time, so a single
+    // location->name lookup is unambiguous. Either strId path may fire here.
+    if (s_currentContainerLocation >= 0 && isApDummyAnyStrId(strId))
     {
         auto locIt = s_locationIndex.find(s_currentContainerLocation);
         if (locIt != s_locationIndex.end())
@@ -198,11 +236,15 @@ const uint16_t *resolveApItemName(uint16_t strId)
         }
     }
 
-    // Resolve per-slot custom AP item names from the current shop context.
-    // The shop renderer computes strId from itemType directly (itemType + 0x2000 for
-    // the shop list, itemType + 294 for the info panel). We intercept those actual
-    // strIds here and resolve the currently selected slot to a scouted item name.
-    if (s_currentShopId >= 0 && s_pCurrentShop && isApDummyStrId(strId))
+    // Shop path: only resolve while the player is actually looking at a shop
+    // menu. Without this gate, stale shop context bleeds the scouted name into
+    // cutscene area titles, brush textboxes, etc. (issue #113). And only the
+    // info-panel strId resolves to the selected slot - the shop-list strId is
+    // shared across every visible row, so resolving by selected slot would make
+    // all row names flicker as the cursor moves (issue #124). The shop list
+    // falls through to the kShopListBase->kInfoPanelBase remap in
+    // hookGetMSDString, which yields the dummy type's generic name.
+    if (s_currentShopId >= 0 && s_pCurrentShop && isShopMenuActive() && isApDummyInfoPanelStrId(strId))
     {
         // Offsets validated against decompiled FUN_18043ca30 (cItemShop::PurchaseItem)
         auto *shopBase = reinterpret_cast<uint8_t *>(s_pCurrentShop);
@@ -228,10 +270,11 @@ static const uint16_t *__fastcall hookGetMSDString(void *pBase, uint16_t index)
     // Shop list strIds use itemType + 0x2000, but our MSD overrides are at
     // itemType + 294 (info panel path). Remap so items that don't normally
     // appear in shops (HourglassOrb, Yen, Praise, dummy types, etc.) resolve
-    // to the same name we patched into the info panel path.
-    constexpr uint16_t kShopListBase = 0x2000;
-    constexpr uint16_t kInfoPanelBase = 294;
-    if (s_currentShopId >= 0 && index >= kShopListBase && index < kShopListBase + okami::ItemTypes::NUM_ITEM_TYPES)
+    // to the same name we patched into the info panel path. Gated by the live
+    // "Item shop menu" GlobalGameState bit so the remap doesn't fire in
+    // cutscenes, where strIds in the 0x2000+ range may belong to unrelated
+    // dialog and would otherwise be silently rewritten (issue #113).
+    if (isShopMenuActive() && index >= kShopListBase && index < kShopListBase + okami::ItemTypes::NUM_ITEM_TYPES)
     {
         uint16_t remapped = static_cast<uint16_t>((index - kShopListBase) + kInfoPanelBase);
         return s_origGetMSDString(pBase, remapped);
@@ -332,6 +375,12 @@ void resetState()
     s_nextCustomIndex = kCustomStringBase;
     clearShopContext();
     clearContainerContext();
+    s_shopMenuActiveOverride = -1;
+}
+
+void setShopMenuActiveOverrideForTests(int state)
+{
+    s_shopMenuActiveOverride = state < 0 ? -1 : (state ? 1 : 0);
 }
 
 bool hasCustomIcons()

--- a/src/okami-apclient/itempatch.hpp
+++ b/src/okami-apclient/itempatch.hpp
@@ -70,4 +70,10 @@ void setHasCustomIconsForTests(bool present);
 /// gates shop-context MSD substitutions. Pass 0 or 1 to force the result; pass
 /// any negative value to clear the override and resume reading the live bit.
 void setShopMenuActiveOverrideForTests(int state);
+
+/// Test-only: install a stub for the original GetMSDString function so tests
+/// can drive hookGetMSDString and verify pass-through behavior. Pass nullptr
+/// to clear.
+using GetMSDStringForTestsFn = const uint16_t *(__fastcall *)(void *, uint16_t);
+void setOrigGetMSDStringForTests(GetMSDStringForTestsFn fn);
 } // namespace itempatch

--- a/src/okami-apclient/itempatch.hpp
+++ b/src/okami-apclient/itempatch.hpp
@@ -65,4 +65,9 @@ bool hasCustomIcons();
 /// initializeEarly(). Used by ShopMan tests to exercise the
 /// "icons-failed-to-build" fallback branch.
 void setHasCustomIconsForTests(bool present);
+
+/// Test-only: override the "Item shop menu" GlobalGameState bit lookup that
+/// gates shop-context MSD substitutions. Pass 0 or 1 to force the result; pass
+/// any negative value to clear the override and resume reading the live bit.
+void setShopMenuActiveOverrideForTests(int state);
 } // namespace itempatch

--- a/tests/test_itempatch.cpp
+++ b/tests/test_itempatch.cpp
@@ -761,3 +761,67 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: container path still re
 
     itempatch::clearContainerContext();
 }
+
+namespace
+{
+const uint16_t *__fastcall stubOrigGetMSDString(void * /*pBase*/, uint16_t index)
+{
+    // Sentinel return value so the test can assert pass-through happened.
+    // The pointer's identity is what matters; the contents are irrelevant.
+    static thread_local uint16_t s_lastIndex = 0;
+    s_lastIndex = index;
+    return reinterpret_cast<const uint16_t *>(&s_lastIndex);
+}
+} // namespace
+
+TEST_CASE("hookGetMSDString: virtual scouted-name indices do not leak into unrelated MSD lookups (issue #113)",
+          "[itempatch][hooks][regression]")
+{
+    // The bleed-through that survived the first round of fixes: every scouted
+    // item registered through registerScoutedItemName claims a virtual MSD
+    // index starting at 0x1000 (kCustomStringBase). The game's own MSD files
+    // also allocate strIds throughout that range -- area-banner strings,
+    // brush textboxes, dialog snippets, etc. The previous fallback in
+    // hookGetMSDString blindly returned our scouted name whenever a query's
+    // index >= 0x1000 happened to collide with a registered virtual idx,
+    // which is why entering Shinshu showed "Progressive Cherry Bomb" as the
+    // area banner.
+    wolf::mock::reset();
+    itempatch::initializeEarly();
+    itempatch::initialize();
+    itempatch::resetState();
+
+    // Set up a stub for the original GetMSDString so the hook can pass through
+    // safely. The stub returns a sentinel pointer; we assert against it.
+    itempatch::setOrigGetMSDStringForTests(&stubOrigGetMSDString);
+
+    // Register a scouted name -- it lands at virtual idx 0x1000.
+    itempatch::registerScoutedItemName(50000, "Cherry Bomb");
+
+    // Player is in a cutscene: no shop, no container context. The game queries
+    // an MSD strId of 0x1000 (e.g. for an area banner that happens to be
+    // assigned that strId in the per-area MSD).
+    itempatch::setShopMenuActiveOverrideForTests(0);
+    itempatch::setShopPointer(nullptr);
+    itempatch::setCurrentShopId(-1);
+    itempatch::clearContainerContext();
+
+    auto it = wolf::mock::registeredHooks.find(0x1C8A80);
+    REQUIRE(it != wolf::mock::registeredHooks.end());
+    using HookFn = const uint16_t *(__fastcall *)(void *, uint16_t);
+    auto fn = reinterpret_cast<HookFn>(it->second);
+
+    const uint16_t *result = fn(nullptr, 0x1000);
+
+    // Pass-through stub returns the queried strId itself as the first uint16.
+    // The bleed branch would have returned the encoded "Cherry Bomb" string,
+    // whose first character ('C') maps to MSD char 25. Verifying the first
+    // uint16 distinguishes the two outcomes.
+    REQUIRE(result != nullptr);
+    auto cherryBomb = okami::MSDManager::CompileString("Cherry Bomb");
+    REQUIRE(result[0] != cherryBomb[0]);
+    REQUIRE(result[0] == 0x1000); // sentinel from stub: the queried index
+
+    itempatch::setOrigGetMSDStringForTests(nullptr);
+    itempatch::resetState();
+}

--- a/tests/test_itempatch.cpp
+++ b/tests/test_itempatch.cpp
@@ -455,15 +455,15 @@ struct ShopContextFixture
     }
 };
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns custom string for info panel strId (type+294)", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns custom string for info panel strId (type+0x2000)", "[itempatch][resolve]")
 {
     // Register "Fire Arrow" at slot 0
     int64_t locId = locationIdForSlot(0);
     itempatch::registerScoutedItemName(locId, "Fire Arrow");
     selectSlot(0, 0);
 
-    // Info panel strId for ForeignStandardItem: 120 + 294 = 414
-    const uint16_t *result = itempatch::resolveApItemName(414);
+    // Info panel strId for ForeignStandardItem: 0x2000 + 120 = 8312
+    const uint16_t *result = itempatch::resolveApItemName(8312);
     REQUIRE(result != nullptr);
 
     // Verify the returned string matches CompileString("Fire Arrow")
@@ -481,14 +481,14 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: only info panel strId r
     itempatch::registerScoutedItemName(locId, "Ice Rod");
     selectSlot(0, 2);
 
-    // Info panel strId (294 + ForeignProgressionItem) renders the SELECTED slot's
-    // detail name, so resolving it to the scouted name is correct.
-    REQUIRE(itempatch::resolveApItemName(424) != nullptr);
-    // Shop list strId (0x2000 + ForeignProgressionItem) is shared across every
+    // Info panel strId (0x2000 + ForeignProgressionItem) renders the SELECTED
+    // slot's detail name, so resolving it to the scouted name is correct.
+    REQUIRE(itempatch::resolveApItemName(8322) != nullptr);
+    // Shop list strId (294 + ForeignProgressionItem) is shared across every
     // visible row of that dummy type, so resolveApItemName must NOT bind it to
-    // the selected slot - it falls through to the generic "Archipelago
-    // Progression" name via the remap in hookGetMSDString. (issue #124)
-    REQUIRE(itempatch::resolveApItemName(8322) == nullptr);
+    // the selected slot - it falls through to the override "Archipelago
+    // Progression" set in hookLoadCore20MSD. (issue #124)
+    REQUIRE(itempatch::resolveApItemName(424) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr for non-AP strId", "[itempatch][resolve]")
@@ -530,7 +530,7 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when no
     selectSlot(0, 3);
 
     // Slot 3 has no registered name
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects info-panel slot selection", "[itempatch][resolve]")
@@ -541,14 +541,14 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects i
 
     // Select slot 0 (scroll=0, visual=0)
     selectSlot(0, 0);
-    const uint16_t *result0 = itempatch::resolveApItemName(414); // 294 + ForeignStandardItem (info panel)
+    const uint16_t *result0 = itempatch::resolveApItemName(8312); // 0x2000 + ForeignStandardItem (info panel)
     REQUIRE(result0 != nullptr);
     auto expected0 = okami::MSDManager::CompileString("Slot Zero Item");
     REQUIRE(result0[0] == expected0[0]);
 
     // Select slot 7 (scroll=5, visual=2)
     selectSlot(5, 2);
-    const uint16_t *result7 = itempatch::resolveApItemName(414);
+    const uint16_t *result7 = itempatch::resolveApItemName(8312);
     REQUIRE(result7 != nullptr);
     auto expected7 = okami::MSDManager::CompileString("Slot Seven Item");
     REQUIRE(result7[0] == expected7[0]);
@@ -564,24 +564,24 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: all three Foreign AP it
     itempatch::registerScoutedItemName(locationIdForSlot(11), "Progression Thing");
     itempatch::registerScoutedItemName(locationIdForSlot(12), "Trap Thing");
 
-    // Info panel strIds (294+type) resolve to the selected slot's name.
-    // List strIds (0x2000+type) intentionally fall through to the generic
-    // dummy name remap (issue #124).
+    // Info panel strIds (0x2000+type) resolve to the selected slot's name.
+    // List strIds (294+type) intentionally fall through to the override
+    // generic dummy name (issue #124).
 
-    // ForeignStandardItem: info=414, list=8312
+    // ForeignStandardItem: info=8312, list=414
     selectSlot(10, 0);
-    REQUIRE(itempatch::resolveApItemName(414) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8312) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
 
-    // ForeignProgressionItem: info=424, list=8322
+    // ForeignProgressionItem: info=8322, list=424
     selectSlot(11, 0);
-    REQUIRE(itempatch::resolveApItemName(424) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8322) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8322) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(424) == nullptr);
 
-    // ForeignTrapItem: info=469, list=8367
+    // ForeignTrapItem: info=8367, list=469
     selectSlot(12, 0);
-    REQUIRE(itempatch::resolveApItemName(469) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8367) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8367) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(469) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when shop pointer is null", "[itempatch][resolve]")
@@ -592,8 +592,8 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when sh
     // Null out just the shop pointer, keep shopId valid
     itempatch::setShopPointer(nullptr);
 
-    // 414 = ForeignStandardItem + 294 (info panel path)
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
+    // 8312 = 0x2000 + ForeignStandardItem (info panel path)
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: resolves Okami-native dummy info-panel strIds", "[itempatch][resolve]")
@@ -603,14 +603,14 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: resolves Okami-native d
     selectSlot(0, 0);
 
     // OkamiStandardItem (162), OkamiProgressionItem (168), OkamiTrapItem (172)
-    // Info panel (294+type) resolves to the selected slot's scouted name.
-    // List (0x2000+type) intentionally falls through (issue #124).
-    REQUIRE(itempatch::resolveApItemName(162 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(162 + 0x2000) == nullptr);
-    REQUIRE(itempatch::resolveApItemName(168 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(168 + 0x2000) == nullptr);
-    REQUIRE(itempatch::resolveApItemName(172 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(172 + 0x2000) == nullptr);
+    // Info panel (0x2000+type) resolves to the selected slot's scouted name.
+    // List (294+type) intentionally falls through (issue #124).
+    REQUIRE(itempatch::resolveApItemName(162 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(162 + 294) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(168 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(168 + 294) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(172 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(172 + 294) == nullptr);
 }
 
 TEST_CASE("clearShopContext: resets both shop ID and pointer", "[itempatch][live]")
@@ -625,7 +625,7 @@ TEST_CASE("clearShopContext: resets both shop ID and pointer", "[itempatch][live
 
     // After clearing, resolve should return nullptr even with a registered name
     itempatch::registerScoutedItemName(checks::getShopCheckId(3, 0), "Cleared Item");
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr); // info panel strId
     itempatch::resetState();
 }
 
@@ -640,8 +640,8 @@ TEST_CASE("resetState: clears all custom string registrations", "[itempatch][liv
     buf[0x8B] = 0;
 
     itempatch::registerScoutedItemName(checks::getShopCheckId(5, 0), "Reset Test");
-    // Verify it resolves before reset (use info panel path: 294 + ForeignStandardItem = 414)
-    REQUIRE(itempatch::resolveApItemName(414) != nullptr);
+    // Verify it resolves before reset (use info panel path: 0x2000 + ForeignStandardItem = 8312)
+    REQUIRE(itempatch::resolveApItemName(8312) != nullptr);
 
     itempatch::resetState();
 
@@ -650,7 +650,7 @@ TEST_CASE("resetState: clears all custom string registrations", "[itempatch][liv
     itempatch::setShopMenuActiveOverrideForTests(1);
     itempatch::setCurrentShopId(5);
     itempatch::setShopPointer(buf);
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
 
     itempatch::resetState(); // clean up
 }
@@ -659,26 +659,59 @@ TEST_CASE("resetState: clears all custom string registrations", "[itempatch][liv
 // Regression tests
 // ============================================================================
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: shop list path is stable as cursor moves (issue #124)",
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: shop list path is stable as cursor moves between same-type dummies (issue #124)",
                  "[itempatch][resolve][regression]")
 {
-    // Two shop slots both happen to be ForeignStandardItem dummies but back
-    // different scouted items. The shop renderer queries the same strId
-    // (0x2000 + ForeignStandardItem) for every visible row of that type, so a
-    // slot-keyed lookup would make every row's name flicker to whichever slot
-    // is currently selected as the user moves the cursor (issue #124).
-    itempatch::registerScoutedItemName(locationIdForSlot(0), "Item Alpha");
-    itempatch::registerScoutedItemName(locationIdForSlot(1), "Item Bravo");
+    // Reproduces the bug shown in the user-supplied screenshots: a shop has
+    // two OkamiProgression dummy slots (1 and 3) backing different scouted
+    // items. The shop's row LIST queries `294 + OkamiProgressionItem` for both
+    // rows. resolveApItemName must NOT bind that strId to the selected slot,
+    // or both rows would render as whichever slot is currently selected and
+    // visibly flicker between "Greensprout (Bloom)" and "Progressive Power
+    // Slash" as the cursor moves between them.
+    itempatch::registerScoutedItemName(locationIdForSlot(1), "Greensprout (Bloom)");
+    itempatch::registerScoutedItemName(locationIdForSlot(3), "Progressive Power Slash");
 
-    constexpr uint16_t kListStrId = 0x2000 + okami::ItemTypes::ForeignStandardItem;
+    constexpr uint16_t kListStrId = okami::ItemTypes::OkamiProgressionItem + 294;
 
-    selectSlot(0, 0);
-    const uint16_t *whenSlot0Selected = itempatch::resolveApItemName(kListStrId);
     selectSlot(0, 1);
     const uint16_t *whenSlot1Selected = itempatch::resolveApItemName(kListStrId);
+    selectSlot(0, 3);
+    const uint16_t *whenSlot3Selected = itempatch::resolveApItemName(kListStrId);
 
-    // The resolution must not depend on the selected slot for the list path.
-    REQUIRE(whenSlot0Selected == whenSlot1Selected);
+    // List rows of the same dummy type must resolve identically regardless of
+    // selection, so the row text is stable as the cursor moves.
+    REQUIRE(whenSlot1Selected == whenSlot3Selected);
+    REQUIRE(whenSlot1Selected == nullptr); // falls through to override
+}
+
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: info panel still tracks selected slot's scouted name",
+                 "[itempatch][resolve][regression]")
+{
+    // Companion to the issue #124 regression: the info-panel strId path
+    // (0x2000 + dummyType) must continue to resolve to the selected slot's
+    // scouted name, since only one item is shown there at a time. Without
+    // this, the bottom info area shows the generic dummy override (e.g.
+    // "Okami Progression") even for the highlighted item, making it
+    // impossible to tell what's actually for sale.
+    itempatch::registerScoutedItemName(locationIdForSlot(1), "Greensprout (Bloom)");
+    itempatch::registerScoutedItemName(locationIdForSlot(3), "Progressive Power Slash");
+
+    constexpr uint16_t kInfoStrId = okami::ItemTypes::OkamiProgressionItem + 0x2000;
+
+    selectSlot(0, 1);
+    const uint16_t *infoSlot1 = itempatch::resolveApItemName(kInfoStrId);
+    selectSlot(0, 3);
+    const uint16_t *infoSlot3 = itempatch::resolveApItemName(kInfoStrId);
+
+    REQUIRE(infoSlot1 != nullptr);
+    REQUIRE(infoSlot3 != nullptr);
+    REQUIRE(infoSlot1 != infoSlot3);
+
+    auto greensprout = okami::MSDManager::CompileString("Greensprout (Bloom)");
+    auto powerSlash = okami::MSDManager::CompileString("Progressive Power Slash");
+    REQUIRE(infoSlot1[0] == greensprout[0]);
+    REQUIRE(infoSlot3[0] == powerSlash[0]);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when shop menu is closed (issue #113)",
@@ -697,8 +730,8 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when s
     itempatch::setShopMenuActiveOverrideForTests(0);
 
     // Both AP dummy strId paths must NOT substitute scouted names.
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);  // info panel
-    REQUIRE(itempatch::resolveApItemName(8312) == nullptr); // shop list
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);  // shop list
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr); // info panel
     // Okami-native dummy types must also not substitute.
     REQUIRE(itempatch::resolveApItemName(okami::ItemTypes::OkamiProgressionItem + 294) == nullptr);
     REQUIRE(itempatch::resolveApItemName(okami::ItemTypes::OkamiProgressionItem + 0x2000) == nullptr);
@@ -723,8 +756,8 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: container path still re
 
     // Both list and info-panel strId paths should resolve via the container
     // branch since only one floating name is being rendered.
-    REQUIRE(itempatch::resolveApItemName(414) != nullptr);  // info panel path
-    REQUIRE(itempatch::resolveApItemName(8312) != nullptr); // list path
+    REQUIRE(itempatch::resolveApItemName(414) != nullptr);  // list path
+    REQUIRE(itempatch::resolveApItemName(8312) != nullptr); // info panel path
 
     itempatch::clearContainerContext();
 }

--- a/tests/test_itempatch.cpp
+++ b/tests/test_itempatch.cpp
@@ -428,6 +428,9 @@ struct ShopContextFixture
     {
         // Clean slate: clear all registrations and shop context from prior tests
         itempatch::resetState();
+        // Force the "Item shop menu" GlobalGameState gate so the shop path
+        // resolves without needing real game memory.
+        itempatch::setShopMenuActiveOverrideForTests(1);
         // Set up a valid shop context: shop ID, shop pointer with scroll/select at slot 0
         itempatch::setCurrentShopId(kShopId);
         mockShop[0x8A] = 0; // scrollOffset
@@ -452,15 +455,15 @@ struct ShopContextFixture
     }
 };
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns custom string for info panel strId (type+0x2000)", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns custom string for info panel strId (type+294)", "[itempatch][resolve]")
 {
     // Register "Fire Arrow" at slot 0
     int64_t locId = locationIdForSlot(0);
     itempatch::registerScoutedItemName(locId, "Fire Arrow");
     selectSlot(0, 0);
 
-    // Info panel strId for ForeignStandardItem: 120 + 0x2000 = 8312
-    const uint16_t *result = itempatch::resolveApItemName(8312);
+    // Info panel strId for ForeignStandardItem: 120 + 294 = 414
+    const uint16_t *result = itempatch::resolveApItemName(414);
     REQUIRE(result != nullptr);
 
     // Verify the returned string matches CompileString("Fire Arrow")
@@ -472,15 +475,20 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns custom string f
     }
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: resolves both list and info panel strIds", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: only info panel strId resolves; list strId falls through", "[itempatch][resolve]")
 {
     int64_t locId = locationIdForSlot(2);
     itempatch::registerScoutedItemName(locId, "Ice Rod");
     selectSlot(0, 2);
 
-    // Both paths resolve to the selected slot's scouted name
-    REQUIRE(itempatch::resolveApItemName(424) != nullptr);  // 294 + ForeignProgressionItem (list)
-    REQUIRE(itempatch::resolveApItemName(8322) != nullptr); // 0x2000 + ForeignProgressionItem (info panel)
+    // Info panel strId (294 + ForeignProgressionItem) renders the SELECTED slot's
+    // detail name, so resolving it to the scouted name is correct.
+    REQUIRE(itempatch::resolveApItemName(424) != nullptr);
+    // Shop list strId (0x2000 + ForeignProgressionItem) is shared across every
+    // visible row of that dummy type, so resolveApItemName must NOT bind it to
+    // the selected slot - it falls through to the generic "Archipelago
+    // Progression" name via the remap in hookGetMSDString. (issue #124)
+    REQUIRE(itempatch::resolveApItemName(8322) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr for non-AP strId", "[itempatch][resolve]")
@@ -510,8 +518,8 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when no
     // Clear shop context — should fall through
     itempatch::clearShopContext();
 
-    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
-    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);  // info panel strId
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr); // shop list strId
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when no name registered for slot", "[itempatch][resolve]")
@@ -525,7 +533,7 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when no
     REQUIRE(itempatch::resolveApItemName(414) == nullptr);
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects slot selection", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects info-panel slot selection", "[itempatch][resolve]")
 {
     // Register names at slots 0 and 7
     itempatch::registerScoutedItemName(locationIdForSlot(0), "Slot Zero Item");
@@ -533,14 +541,14 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects s
 
     // Select slot 0 (scroll=0, visual=0)
     selectSlot(0, 0);
-    const uint16_t *result0 = itempatch::resolveApItemName(8312); // 0x2000 + ForeignStandardItem
+    const uint16_t *result0 = itempatch::resolveApItemName(414); // 294 + ForeignStandardItem (info panel)
     REQUIRE(result0 != nullptr);
     auto expected0 = okami::MSDManager::CompileString("Slot Zero Item");
     REQUIRE(result0[0] == expected0[0]);
 
     // Select slot 7 (scroll=5, visual=2)
     selectSlot(5, 2);
-    const uint16_t *result7 = itempatch::resolveApItemName(8312);
+    const uint16_t *result7 = itempatch::resolveApItemName(414);
     REQUIRE(result7 != nullptr);
     auto expected7 = okami::MSDManager::CompileString("Slot Seven Item");
     REQUIRE(result7[0] == expected7[0]);
@@ -549,29 +557,31 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: scroll offset affects s
     REQUIRE(result0 != result7);
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: all three AP item types resolve correctly", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: all three Foreign AP item types resolve via info panel strId", "[itempatch][resolve]")
 {
-    // Register names at slots 0, 1, 2 for different AP item types
+    // Register names at slots 10, 11, 12 for different AP item types
     itempatch::registerScoutedItemName(locationIdForSlot(10), "Standard Thing");
     itempatch::registerScoutedItemName(locationIdForSlot(11), "Progression Thing");
     itempatch::registerScoutedItemName(locationIdForSlot(12), "Trap Thing");
 
-    // Both list (294+type) and info panel (0x2000+type) strIds should resolve
+    // Info panel strIds (294+type) resolve to the selected slot's name.
+    // List strIds (0x2000+type) intentionally fall through to the generic
+    // dummy name remap (issue #124).
 
-    // ForeignStandardItem: list=414, info=8312
+    // ForeignStandardItem: info=414, list=8312
     selectSlot(10, 0);
     REQUIRE(itempatch::resolveApItemName(414) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8312) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
 
-    // ForeignProgressionItem: list=424, info=8322
+    // ForeignProgressionItem: info=424, list=8322
     selectSlot(11, 0);
     REQUIRE(itempatch::resolveApItemName(424) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8322) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(8322) == nullptr);
 
-    // ForeignTrapItem: list=469, info=8367
+    // ForeignTrapItem: info=469, list=8367
     selectSlot(12, 0);
     REQUIRE(itempatch::resolveApItemName(469) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(8367) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(8367) == nullptr);
 }
 
 TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when shop pointer is null", "[itempatch][resolve]")
@@ -582,29 +592,32 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: returns nullptr when sh
     // Null out just the shop pointer, keep shopId valid
     itempatch::setShopPointer(nullptr);
 
-    // 8312 = ForeignStandardItem + 0x2000 (info panel path)
-    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
+    // 414 = ForeignStandardItem + 294 (info panel path)
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: resolves Okami-native dummy strIds", "[itempatch][resolve]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: resolves Okami-native dummy info-panel strIds", "[itempatch][resolve]")
 {
     // Register a name at slot 0 so the shop context is valid
     itempatch::registerScoutedItemName(locationIdForSlot(0), "Power Slash");
     selectSlot(0, 0);
 
     // OkamiStandardItem (162), OkamiProgressionItem (168), OkamiTrapItem (172)
-    // Both list (294+type) and info panel (0x2000+type) should resolve
+    // Info panel (294+type) resolves to the selected slot's scouted name.
+    // List (0x2000+type) intentionally falls through (issue #124).
     REQUIRE(itempatch::resolveApItemName(162 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(162 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(162 + 0x2000) == nullptr);
     REQUIRE(itempatch::resolveApItemName(168 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(168 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(168 + 0x2000) == nullptr);
     REQUIRE(itempatch::resolveApItemName(172 + 294) != nullptr);
-    REQUIRE(itempatch::resolveApItemName(172 + 0x2000) != nullptr);
+    REQUIRE(itempatch::resolveApItemName(172 + 0x2000) == nullptr);
 }
 
 TEST_CASE("clearShopContext: resets both shop ID and pointer", "[itempatch][live]")
 {
     uint8_t buf[0x8C] = {};
+    itempatch::resetState();
+    itempatch::setShopMenuActiveOverrideForTests(1);
     itempatch::setCurrentShopId(3);
     itempatch::setShopPointer(buf);
 
@@ -613,26 +626,105 @@ TEST_CASE("clearShopContext: resets both shop ID and pointer", "[itempatch][live
     // After clearing, resolve should return nullptr even with a registered name
     itempatch::registerScoutedItemName(checks::getShopCheckId(3, 0), "Cleared Item");
     REQUIRE(itempatch::resolveApItemName(414) == nullptr);
+    itempatch::resetState();
 }
 
 TEST_CASE("resetState: clears all custom string registrations", "[itempatch][live]")
 {
     uint8_t buf[0x8C] = {};
+    itempatch::resetState();
+    itempatch::setShopMenuActiveOverrideForTests(1);
     itempatch::setCurrentShopId(5);
     itempatch::setShopPointer(buf);
     buf[0x8A] = 0;
     buf[0x8B] = 0;
 
     itempatch::registerScoutedItemName(checks::getShopCheckId(5, 0), "Reset Test");
-    // Verify it resolves before reset (use info panel path: 0x2000 + ForeignStandardItem)
-    REQUIRE(itempatch::resolveApItemName(8312) != nullptr);
+    // Verify it resolves before reset (use info panel path: 294 + ForeignStandardItem = 414)
+    REQUIRE(itempatch::resolveApItemName(414) != nullptr);
 
     itempatch::resetState();
 
-    // After reset, nothing should resolve (shop context cleared + registrations gone)
+    // After reset, nothing should resolve (shop context cleared + registrations gone +
+    // shop menu override reset to live state, which reads zero in tests).
+    itempatch::setShopMenuActiveOverrideForTests(1);
     itempatch::setCurrentShopId(5);
     itempatch::setShopPointer(buf);
-    REQUIRE(itempatch::resolveApItemName(8312) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);
 
     itempatch::resetState(); // clean up
+}
+
+// ============================================================================
+// Regression tests
+// ============================================================================
+
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: shop list path is stable as cursor moves (issue #124)",
+                 "[itempatch][resolve][regression]")
+{
+    // Two shop slots both happen to be ForeignStandardItem dummies but back
+    // different scouted items. The shop renderer queries the same strId
+    // (0x2000 + ForeignStandardItem) for every visible row of that type, so a
+    // slot-keyed lookup would make every row's name flicker to whichever slot
+    // is currently selected as the user moves the cursor (issue #124).
+    itempatch::registerScoutedItemName(locationIdForSlot(0), "Item Alpha");
+    itempatch::registerScoutedItemName(locationIdForSlot(1), "Item Bravo");
+
+    constexpr uint16_t kListStrId = 0x2000 + okami::ItemTypes::ForeignStandardItem;
+
+    selectSlot(0, 0);
+    const uint16_t *whenSlot0Selected = itempatch::resolveApItemName(kListStrId);
+    selectSlot(0, 1);
+    const uint16_t *whenSlot1Selected = itempatch::resolveApItemName(kListStrId);
+
+    // The resolution must not depend on the selected slot for the list path.
+    REQUIRE(whenSlot0Selected == whenSlot1Selected);
+}
+
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when shop menu is closed (issue #113)",
+                 "[itempatch][resolve][regression]")
+{
+    // Reproduce the cutscene/Mist/area-name leak: shop context lingers from a
+    // previous shop visit (s_currentShopId, s_pCurrentShop still set), and
+    // the renderer happens to query an MSD strId that overlaps an AP dummy
+    // strId. Without the gate, this returns the cached scouted name and the
+    // cutscene displays e.g. "Progressive Cherry Bomb" instead of the area.
+    itempatch::registerScoutedItemName(locationIdForSlot(0), "Cherry Bomb");
+    selectSlot(0, 0);
+
+    // Player exits the shop. The shop menu GlobalGameState bit clears, but
+    // s_currentShopId and s_pCurrentShop are still set from the last visit.
+    itempatch::setShopMenuActiveOverrideForTests(0);
+
+    // Both AP dummy strId paths must NOT substitute scouted names.
+    REQUIRE(itempatch::resolveApItemName(414) == nullptr);  // info panel
+    REQUIRE(itempatch::resolveApItemName(8312) == nullptr); // shop list
+    // Okami-native dummy types must also not substitute.
+    REQUIRE(itempatch::resolveApItemName(okami::ItemTypes::OkamiProgressionItem + 294) == nullptr);
+    REQUIRE(itempatch::resolveApItemName(okami::ItemTypes::OkamiProgressionItem + 0x2000) == nullptr);
+}
+
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: container path still resolves regardless of shop menu state",
+                 "[itempatch][resolve][regression]")
+{
+    // The container path is independent of the shop menu - a chest opened in
+    // the overworld should still display the scouted name above the floating
+    // item. Verify the issue #113 gate didn't accidentally block this path.
+    constexpr int64_t kContainerLoc = 9001;
+    itempatch::registerScoutedItemName(kContainerLoc, "Container Treasure");
+
+    // Shop menu is OFF (player is on the overworld), shop pointer is null.
+    itempatch::setShopMenuActiveOverrideForTests(0);
+    itempatch::setShopPointer(nullptr);
+    itempatch::setCurrentShopId(-1);
+
+    // Container context briefly active during pickup
+    itempatch::setContainerContext(kContainerLoc);
+
+    // Both list and info-panel strId paths should resolve via the container
+    // branch since only one floating name is being rendered.
+    REQUIRE(itempatch::resolveApItemName(414) != nullptr);  // info panel path
+    REQUIRE(itempatch::resolveApItemName(8312) != nullptr); // list path
+
+    itempatch::clearContainerContext();
 }


### PR DESCRIPTION
Most of the string lookup issues were due to stale data being persisted in shop-related fields even after leaving a shop.

## Changes
- isShopMenuActive() helper that reads active shop GlobalGameState bit, gating context resolution and strid lookup instead of s_currentShopId
- split isApDummyStrId into separate info and shop-list paths
- Container path keeps resolving on either paths

## Related Issues
Fixes #113, Fixes #124, 