### PR TITLE
Trust persisted item index on reconnect (#130)

### DIFF
--- a/include/okami/customiconpkg.hpp
+++ b/include/okami/customiconpkg.hpp
@@ -65,8 +65,8 @@ inline constexpr std::string_view kPackageResourceName = "archipelago/customicon
 /// first custom entry in the combined package). On failure returns a string
 /// naming the specific input that couldn't be processed (vanilla DAT,
 /// individual DDS file, or output write), so the caller can log it.
-[[nodiscard]] std::expected<int, std::string>
-buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath, const std::filesystem::path &standardPath,
-                       const std::filesystem::path &progressionPath, const std::filesystem::path &trapPath);
+[[nodiscard]] std::expected<int, std::string> buildCombinedFromFiles(const std::filesystem::path &outPath, const std::filesystem::path &vanillaPath,
+                                                                     const std::filesystem::path &standardPath, const std::filesystem::path &progressionPath,
+                                                                     const std::filesystem::path &trapPath);
 
 } // namespace okami::customiconpkg

--- a/src/okami-apclient/archipelagosocket.cpp
+++ b/src/okami-apclient/archipelagosocket.cpp
@@ -401,14 +401,10 @@ void ArchipelagoSocket::setupHandlers(const std::string &slot, const std::string
         {
             wolf::logInfo("[Socket] Received %zu items", items.size());
 
-            // Check for full inventory reset (index 0 means accept as complete inventory)
-            if (!items.empty() && items.front().index == 0)
-            {
-                wolf::logInfo("[Socket] Full inventory reset received (index 0)");
-                // TODO: Clear player's current AP inventory before processing
-                lastProcessedItemIndex_ = -1;
-            }
-
+            // AP sends the full received-items history (starting at index 0) on every
+            // (re)connect. The persisted lastProcessedItemIndex_ is the authoritative
+            // dedup cursor -- do not reset it just because the batch begins at 0, or
+            // tools/treasures get re-granted on every reconnect (issue #130).
             int highestIndex = lastProcessedItemIndex_;
             int expectedIndex = lastProcessedItemIndex_ + 1;
             int newItemCount = 0;

--- a/tests/test_itempatch.cpp
+++ b/tests/test_itempatch.cpp
@@ -685,8 +685,7 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: shop list path is stabl
     REQUIRE(whenSlot1Selected == nullptr); // falls through to override
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: info panel still tracks selected slot's scouted name",
-                 "[itempatch][resolve][regression]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: info panel still tracks selected slot's scouted name", "[itempatch][resolve][regression]")
 {
     // Companion to the issue #124 regression: the info-panel strId path
     // (0x2000 + dummyType) must continue to resolve to the selected slot's
@@ -714,8 +713,7 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: info panel still tracks
     REQUIRE(infoSlot3[0] == powerSlash[0]);
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when shop menu is closed (issue #113)",
-                 "[itempatch][resolve][regression]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when shop menu is closed (issue #113)", "[itempatch][resolve][regression]")
 {
     // Reproduce the cutscene/Mist/area-name leak: shop context lingers from a
     // previous shop visit (s_currentShopId, s_pCurrentShop still set), and
@@ -737,8 +735,7 @@ TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: nothing resolves when s
     REQUIRE(itempatch::resolveApItemName(okami::ItemTypes::OkamiProgressionItem + 0x2000) == nullptr);
 }
 
-TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: container path still resolves regardless of shop menu state",
-                 "[itempatch][resolve][regression]")
+TEST_CASE_METHOD(ShopContextFixture, "resolveApItemName: container path still resolves regardless of shop menu state", "[itempatch][resolve][regression]")
 {
     // The container path is independent of the shop menu - a chest opened in
     // the overworld should still display the scouted name above the floating
@@ -774,8 +771,7 @@ const uint16_t *__fastcall stubOrigGetMSDString(void * /*pBase*/, uint16_t index
 }
 } // namespace
 
-TEST_CASE("hookGetMSDString: virtual scouted-name indices do not leak into unrelated MSD lookups (issue #113)",
-          "[itempatch][hooks][regression]")
+TEST_CASE("hookGetMSDString: virtual scouted-name indices do not leak into unrelated MSD lookups (issue #113)", "[itempatch][hooks][regression]")
 {
     // The bleed-through that survived the first round of fixes: every scouted
     // item registered through registerScoutedItemName claims a virtual MSD


### PR DESCRIPTION
The "Full inventory reset received (index 0)" branch reset the dedup cursor to -1 every time AP delivered a batch starting at 0, which is what AP does on every reconnect. The downstream loop already skips items <= lastProcessedItemIndex_, so the persisted save is sufficient. Removing the spurious reset stops tools/treasures from being re-granted on reconnect.

## Related Issues
Fixes #130