### PR TITLE
Ship icon DDS files in CI build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,8 +152,12 @@ jobs:
           $stageDir = "${{ matrix.config }}"
 
           New-Item -ItemType Directory -Force -Path "$stageDir/apclient"
+          New-Item -ItemType Directory -Force -Path "$stageDir/apclient/game-data/icons"
           Copy-Item "$buildDir/src/okami-apclient/okami-apclient.dll" "$stageDir/apclient/"
           Copy-Item "$buildDir/cacert.pem" "$stageDir/apclient/"
+          Copy-Item "src/okami-apclient/icons/ap_standard.dds" "$stageDir/apclient/game-data/icons/"
+          Copy-Item "src/okami-apclient/icons/ap_progression.dds" "$stageDir/apclient/game-data/icons/"
+          Copy-Item "src/okami-apclient/icons/ap_trap.dds" "$stageDir/apclient/game-data/icons/"
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description
The release workflow stages ap_{standard,progression,trap}.dds under
apclient/game-data/icons/ so installs from a release have the icons
needed to build the combined icon package; without them, shop slots
that hold AP-substituted items fall back to Chestnut. Mirror the same
staging in build.yml so dev builds and PR artifacts ship the icons too
(#129).

## Related Issues
Fixes #129
