### PR TITLE
Widen check ID ranges so map-keyed encodings don't collide

### DIFF
--- a/src/okami-apclient/checks/check_types.hpp
+++ b/src/okami-apclient/checks/check_types.hpp
@@ -9,15 +9,18 @@
  * AP server. Each check has a unique ID computed from its category and
  * game-specific identifiers.
  *
- * ID Range Scheme:
- * - 200000 + brushIndex:                Brush acquisitions
- * - 300000 + shopId*1000 + itemSlot:    Shop purchases
- * - 400000 + mapId*10000 + bitIndex:    World state changes
- * - 500000 + mapId*10000 + bitIndex:    Collected objects
- * - 600000 + mapId*10000 + bitIndex:    Area restorations
- * - 700000 + bitIndex:                  Global flags
- * - 800000 + bitIndex:                  Game progress flags
- * - 900000 + (levelId << 8) + spawnIdx: Container pickups
+ * ID Range Scheme: categories spaced 1e9 apart,
+ * and 1000 slots per inner key (mapId / shopId / levelId).
+ *
+ * - 1_000_000_000 + brushIndex:                Brush acquisitions
+ * - 2_000_000_000 + shopId*1000 + itemSlot:    Shop purchases
+ * - 3_000_000_000 + mapId*1000 + bitIndex:     World state changes
+ * - 4_000_000_000 + mapId*1000 + bitIndex:     Collected objects
+ * - 5_000_000_000 + mapId*1000 + bitIndex:     Area restorations
+ * - 6_000_000_000 + bitIndex:                  Global flags
+ * - 7_000_000_000 + bitIndex:                  Game progress flags
+ * - 8_000_000_000 + levelId*1000 + spawnIdx:   Container pickups
+ *
  */
 namespace checks
 {
@@ -37,15 +40,15 @@ inline constexpr unsigned int monitorToGameBitIndex(unsigned int monitorBitIndex
     return word * 32 + (31 - bitInWord);
 }
 
-// Check ID range bases
-inline constexpr int64_t kBrushAcquisitionBase = 200000;
-inline constexpr int64_t kShopPurchaseBase = 300000;
-inline constexpr int64_t kWorldStateBase = 400000;
-inline constexpr int64_t kCollectedObjectBase = 500000;
-inline constexpr int64_t kAreaRestoredBase = 600000;
-inline constexpr int64_t kGlobalFlagBase = 700000;
-inline constexpr int64_t kGameProgressBase = 800000;
-inline constexpr int64_t kContainerBase = 900000;
+// Check ID range bases. Categories sit 1e9 apart
+inline constexpr int64_t kBrushAcquisitionBase = 1'000'000'000;
+inline constexpr int64_t kShopPurchaseBase = 2'000'000'000;
+inline constexpr int64_t kWorldStateBase = 3'000'000'000;
+inline constexpr int64_t kCollectedObjectBase = 4'000'000'000;
+inline constexpr int64_t kAreaRestoredBase = 5'000'000'000;
+inline constexpr int64_t kGlobalFlagBase = 6'000'000'000;
+inline constexpr int64_t kGameProgressBase = 7'000'000'000;
+inline constexpr int64_t kContainerBase = 8'000'000'000;
 
 /**
  * @brief Calculate check ID for brush acquisition
@@ -61,44 +64,44 @@ inline constexpr int64_t getBrushCheckId(int brushIndex)
  * @brief Calculate check ID for shop purchase
  * @param shopId The game's internal shop ID
  * @param itemSlot The slot number within the shop
- * @return Archipelago check ID (300000 + shopId*1000 + itemSlot)
+ * @return Archipelago check ID (kShopPurchaseBase + shopId*1000 + itemSlot)
  */
 inline constexpr int64_t getShopCheckId(int shopId, int itemSlot)
 {
-    return kShopPurchaseBase + (shopId * 1000) + itemSlot;
+    return kShopPurchaseBase + (static_cast<int64_t>(shopId) * 1000) + itemSlot;
 }
 
 /**
  * @brief Calculate check ID for world state bit change
  * @param mapId The map where the bit change occurred
  * @param bitIndex The specific bit that changed
- * @return Archipelago check ID (400000 + mapId*10000 + bitIndex)
+ * @return Archipelago check ID (kWorldStateBase + mapId*1000 + bitIndex)
  */
 inline constexpr int64_t getWorldStateCheckId(int mapId, int bitIndex)
 {
-    return kWorldStateBase + (mapId * 10000) + bitIndex;
+    return kWorldStateBase + (static_cast<int64_t>(mapId) * 1000) + bitIndex;
 }
 
 /**
  * @brief Calculate check ID for collected object
  * @param mapId The map where the object was collected
  * @param bitIndex The specific object bit that was set
- * @return Archipelago check ID (500000 + mapId*10000 + bitIndex)
+ * @return Archipelago check ID (kCollectedObjectBase + mapId*1000 + bitIndex)
  */
 inline constexpr int64_t getCollectedObjectCheckId(int mapId, int bitIndex)
 {
-    return kCollectedObjectBase + (mapId * 10000) + bitIndex;
+    return kCollectedObjectBase + (static_cast<int64_t>(mapId) * 1000) + bitIndex;
 }
 
 /**
  * @brief Calculate check ID for area restoration
  * @param mapId The map where the area was restored
  * @param bitIndex The specific restoration bit that was set
- * @return Archipelago check ID (600000 + mapId*10000 + bitIndex)
+ * @return Archipelago check ID (kAreaRestoredBase + mapId*1000 + bitIndex)
  */
 inline constexpr int64_t getAreaRestoredCheckId(int mapId, int bitIndex)
 {
-    return kAreaRestoredBase + (mapId * 10000) + bitIndex;
+    return kAreaRestoredBase + (static_cast<int64_t>(mapId) * 1000) + bitIndex;
 }
 
 /**
@@ -125,11 +128,11 @@ inline constexpr int64_t getGameProgressCheckId(int bitIndex)
  * @brief Calculate check ID for container pickup
  * @param levelId The level ID where the container exists
  * @param spawnIdx The spawn table index of the container
- * @return Archipelago check ID (900000 + (levelId << 8) + spawnIdx)
+ * @return Archipelago check ID (kContainerBase + levelId*1000 + spawnIdx)
  */
 inline constexpr int64_t getContainerCheckId(uint16_t levelId, int spawnIdx)
 {
-    return kContainerBase + (static_cast<int64_t>(levelId) << 8) + spawnIdx;
+    return kContainerBase + (static_cast<int64_t>(levelId) * 1000) + spawnIdx;
 }
 
 /**

--- a/tests/test_brush_regression.cpp
+++ b/tests/test_brush_regression.cpp
@@ -449,7 +449,6 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: SET op (operation==0) fires check a
 
     REQUIRE(sentChecks_.size() == 1);
     CHECK(sentChecks_[0] == checks::getBrushCheckId(12));
-    CHECK(sentChecks_[0] == 200012);
 
     tearDown();
 }
@@ -490,9 +489,9 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: bitIndex passed through unchanged i
     brushMan_->tick();
 
     REQUIRE(sentChecks_.size() == 3);
-    CHECK(sentChecks_[0] == 200001);
-    CHECK(sentChecks_[1] == 200022);
-    CHECK(sentChecks_[2] == 200030);
+    CHECK(sentChecks_[0] == checks::getBrushCheckId(1));
+    CHECK(sentChecks_[1] == checks::getBrushCheckId(22));
+    CHECK(sentChecks_[2] == checks::getBrushCheckId(30));
 
     tearDown();
 }
@@ -526,7 +525,7 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: already-obtained bit still queues a
     CHECK_FALSE(wolf::mock::triggerBrushEdit(12, 0)); // pass through
     brushMan_->tick();
     REQUIRE(sentChecks_.size() == 1); // but check IS sent
-    CHECK(sentChecks_[0] == 200012);
+    CHECK(sentChecks_[0] == checks::getBrushCheckId(12));
 
     tearDown();
 }
@@ -539,7 +538,7 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: bit with no APWorld location is ful
     // sub-abilities; otherwise we strip them without an AP item in return.
     // Same shape for the Kamiki Sunrise tutorial: bit 1 (sunrise_default)
     // is set by story progression but has no apworld location.
-    isValidLocation_ = [](int64_t id) { return id == 200004; }; // only Bloom
+    isValidLocation_ = [](int64_t id) { return id == checks::getBrushCheckId(4); }; // only Bloom
 
     setUp();
 
@@ -557,7 +556,7 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: bit with no APWorld location is ful
     CHECK(wolf::mock::triggerBrushEdit(4, 0));
     brushMan_->tick();
     REQUIRE(sentChecks_.size() == 1);
-    CHECK(sentChecks_[0] == 200004);
+    CHECK(sentChecks_[0] == checks::getBrushCheckId(4));
 
     tearDown();
 }

--- a/tests/test_containers.cpp
+++ b/tests/test_containers.cpp
@@ -20,9 +20,9 @@ static_assert(checks::getContainerCheckId(0, 0) == checks::kContainerBase);
 
 TEST_CASE("Container check ID ranges don't overlap between levels", "[containers][check_types]")
 {
-    // This tests a real constraint: encoding must not cause level N's IDs to collide with level N+1
-    // Max spawn index is 255 (8 bits allocated)
-    int64_t level5Max = checks::getContainerCheckId(5, 255);
+    // Encoding must not cause level N's IDs to collide with level N+1.
+    // Inner multiplier is 1000, so spawn indices 0..999 fit per level.
+    int64_t level5Max = checks::getContainerCheckId(5, 999);
     int64_t level6Min = checks::getContainerCheckId(6, 0);
     REQUIRE(level5Max < level6Min);
 }

--- a/tests/test_itempatch.cpp
+++ b/tests/test_itempatch.cpp
@@ -387,12 +387,12 @@ TEST_CASE("CompileString: produces valid MSD encoding with EndDialog terminator"
 TEST_CASE("getShopCheckId produces correct location IDs for shop slots", "[itempatch][shops]")
 {
     // Verify the mapping used by hookGetMSDString to resolve selected slots
-    // getShopCheckId(shopId, slot) = 300000 + shopId*1000 + slot
-    REQUIRE(checks::getShopCheckId(0, 0) == 300000);
-    REQUIRE(checks::getShopCheckId(0, 1) == 300001);
-    REQUIRE(checks::getShopCheckId(5, 0) == 305000);
-    REQUIRE(checks::getShopCheckId(5, 3) == 305003);
-    REQUIRE(checks::getShopCheckId(10, 7) == 310007);
+    // getShopCheckId(shopId, slot) = kShopPurchaseBase + shopId*1000 + slot
+    REQUIRE(checks::getShopCheckId(0, 0) == checks::kShopPurchaseBase);
+    REQUIRE(checks::getShopCheckId(0, 1) == checks::kShopPurchaseBase + 1);
+    REQUIRE(checks::getShopCheckId(5, 0) == checks::kShopPurchaseBase + 5000);
+    REQUIRE(checks::getShopCheckId(5, 3) == checks::kShopPurchaseBase + 5003);
+    REQUIRE(checks::getShopCheckId(10, 7) == checks::kShopPurchaseBase + 10007);
 }
 
 TEST_CASE("registerScoutedItemName: CompileString output matches MSD encoding", "[itempatch][live]")

--- a/tests/test_shops.cpp
+++ b/tests/test_shops.cpp
@@ -26,9 +26,9 @@ TEST_CASE("Shop check ID encoding constraints", "[shops][check_types]")
 {
     SECTION("Shop IDs don't overflow into next category")
     {
-        // Max reasonable: shopId=99, slot=999 -> 399999
-        // WorldState starts at 400000
-        int64_t maxShopCheck = checks::getShopCheckId(99, 999);
+        // Inner multiplier is 1000; even a wildly oversized shopId / slot
+        // pair has to stay below kWorldStateBase.
+        int64_t maxShopCheck = checks::getShopCheckId(999'999, 999);
         REQUIRE(maxShopCheck < checks::kWorldStateBase);
     }
 
@@ -463,7 +463,7 @@ constexpr int kOtherPlayer = 2;
 
 ScoutedItem makeScouted(int64_t apItemId, int destinationPlayer, unsigned flags)
 {
-    return ScoutedItem{.item = apItemId, .location = 300000, .player = destinationPlayer, .flags = flags};
+    return ScoutedItem{.item = apItemId, .location = checks::kShopPurchaseBase, .player = destinationPlayer, .flags = flags};
 }
 } // namespace
 


### PR DESCRIPTION
## Description
Widens the base offset of all the IDs so that they don't overlap when maps are involved

BREAKS APWORLD COMPAT: will mark v0.8.0