### PR TITLE
Set vine_holy_smoke bit when granting Vine (#132)

### DIFF
--- a/src/okami-apclient/rewards/brushes.cpp
+++ b/src/okami-apclient/rewards/brushes.cpp
@@ -123,14 +123,22 @@ std::expected<void, RewardError> grant(int64_t apItemId)
         grantSimpleBrush(static_cast<int>(okami::BrushOverlay::sunrise_default));
     }
 
-    // Bloom (bit 4) is the bloom-circle ability. The two adjacent bits —
-    // greensprout (2) and dot_trees (3) — gate cursed-patch bloom and
+    // Bloom (bit 4) is the bloom-circle ability. The two adjacent bits --
+    // greensprout (2) and dot_trees (3) -- gate cursed-patch bloom and
     // tree-growing respectively, and the apworld doesn't ship them as
     // separate items. Vanilla Sakigami sets all three at once; mirror that.
     if (apItemId == 0x104) // Greensprout (Bloom)
     {
         grantSimpleBrush(static_cast<int>(okami::BrushOverlay::greensprout));
         grantSimpleBrush(static_cast<int>(okami::BrushOverlay::dot_trees));
+    }
+
+    // Vine (bit 19) is the swing ability. The adjacent vine_holy_smoke (20)
+    // gates the green-smoke effect on flowers, and the apworld doesn't
+    // distribute it separately. Mirror vanilla and set both. (#132)
+    if (apItemId == 0x113) // Greensprout (Vine)
+    {
+        grantSimpleBrush(static_cast<int>(okami::BrushOverlay::vine_holy_smoke));
     }
 
     return {};

--- a/tests/test_brush_regression.cpp
+++ b/tests/test_brush_regression.cpp
@@ -227,6 +227,43 @@ TEST_CASE_METHOD(BrushFixture, "Granting non-Bloom brush does not set bits 2 or 
 }
 
 // ============================================================================
+// Vine grant must set both bit 19 (vine_base) AND bit 20 (vine_holy_smoke).
+// vine_holy_smoke gates the green-smoke effect on flowers and the apworld
+// doesn't ship it separately, so grant() has to mirror vanilla. (#132)
+// ============================================================================
+
+TEST_CASE_METHOD(BrushFixture, "Granting Vine sets bits 19 and 20", "[brush][regression][vine]")
+{
+    setUp();
+
+    constexpr int64_t kVineApId = 0x113;
+    auto result = rewardMan_->grantReward(kVineApId);
+    REQUIRE(result.has_value());
+
+    // bits 19 and 20 are both in byte 2: mask 0x08 | 0x10 = 0x18.
+    const auto *src = rawBytes(okami::main::usableBrushes);
+    CHECK((src[2] & 0x18) == 0x18);
+
+    const auto *world = reinterpret_cast<const uint8_t *>(apgame::usableBrushTechniques.get_ptr());
+    CHECK((world[2] & 0x18) == 0x18);
+
+    tearDown();
+}
+
+TEST_CASE_METHOD(BrushFixture, "Granting non-Vine brush does not set bit 20", "[brush][regression][vine]")
+{
+    setUp();
+
+    constexpr int64_t kRejuvenationApId = 0x116;
+    REQUIRE(rewardMan_->grantReward(kRejuvenationApId).has_value());
+
+    const auto *src = rawBytes(okami::main::usableBrushes);
+    CHECK((src[2] & 0x10) == 0); // bit 20 not set
+
+    tearDown();
+}
+
+// ============================================================================
 // Source + copy mirroring: granting writes BOTH BrushData and WorldStateData
 // ============================================================================
 


### PR DESCRIPTION
## Description
bit 20 gates the green-smoke effect on flowers and isn't shipped as a separate AP item, so granting Vine has to set it too. Same shape as the existing Bloom auto-set.

## Related Issues
Fixes #132
