### PR TITLE
Add 'ap' developer-console subcommands

### DIFF
--- a/src/okami-apclient/archipelagosocket.cpp
+++ b/src/okami-apclient/archipelagosocket.cpp
@@ -480,8 +480,13 @@ void ArchipelagoSocket::setupHandlers(const std::string &slot, const std::string
         [this](const APClient::PrintJSONArgs &args)
         {
             std::string text = client_->render_json(args.data);
-            if (!text.empty())
-                notificationwindow::queue(text);
+            if (text.empty())
+                return;
+            notificationwindow::queue(text);
+            // Mirror to the dev console so server replies to slash commands
+            // (/help, /players, /missing, ...) are scrollable history, not just
+            // a brief overlay.
+            wolf::consolePrint(("[AP] " + text).c_str());
         });
 
     client_->set_location_checked_handler(
@@ -628,6 +633,21 @@ void ArchipelagoSocket::sendLocations(const std::vector<int64_t> &locationIDs)
     catch (const std::exception &e)
     {
         wolf::logWarning("[Socket] Failed to send locations: %s", e.what());
+    }
+}
+
+bool ArchipelagoSocket::say(const std::string &text)
+{
+    if (text.empty())
+        return false;
+    try
+    {
+        return withClient([&text](APClient &client) { return client.Say(text); });
+    }
+    catch (const std::exception &e)
+    {
+        wolf::logWarning("[Socket] Say failed: %s", e.what());
+        return false;
     }
 }
 

--- a/src/okami-apclient/archipelagosocket.h
+++ b/src/okami-apclient/archipelagosocket.h
@@ -29,6 +29,7 @@ class ArchipelagoSocket : public ISocket
     void gameFinished() override;
     void poll() override;
     void processMainThreadTasks() override;
+    bool say(const std::string &text) override;
 
     std::string getItemName(int64_t id, int player) const override;
     std::string getLocalItemName(int64_t id) const;

--- a/src/okami-apclient/console_commands.cpp
+++ b/src/okami-apclient/console_commands.cpp
@@ -1,0 +1,151 @@
+#include "console_commands.h"
+
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <wolf_framework.hpp>
+
+#include "isocket.h"
+#include "rewardman.h"
+#include "slotconfig.h"
+
+namespace console_commands
+{
+
+namespace
+{
+
+// Parse a signed 64-bit integer from a string. Accepts decimal and the 0x / 0X
+// hex prefix. Returns true on success.
+bool parseInt64(std::string_view s, int64_t &out)
+{
+    if (s.empty())
+        return false;
+
+    int base = 10;
+    if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+    {
+        s.remove_prefix(2);
+        base = 16;
+    }
+
+    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), out, base);
+    return ec == std::errc{} && ptr == s.data() + s.size();
+}
+
+void cmdStatus(ISocket &socket, const std::vector<std::string> & /*args*/)
+{
+    wolf::consolePrintf("[AP] connected=%d  status=%s", socket.isConnected() ? 1 : 0, socket.getStatus().c_str());
+    if (socket.isConnected())
+    {
+        wolf::consolePrintf("[AP] %s", socket.getConnectionInfo().c_str());
+        wolf::consolePrintf("[AP] slot=%d  uuid=%s", socket.getPlayerSlot(), socket.getUUID().c_str());
+    }
+    if (socket.isSlotConfigReady())
+    {
+        const auto &cfg = socket.getSlotConfig();
+        wolf::consolePrintf("[AP] slot_data: shops=%d brushes=%d containers=%d shopSlots=%d", cfg.randomizeShops ? 1 : 0, cfg.randomizeBrushes ? 1 : 0,
+                            cfg.randomizeContainers ? 1 : 0, cfg.shopSlots);
+    }
+}
+
+void cmdSay(ISocket &socket, const std::vector<std::string> &args)
+{
+    // args[0] is the command name; everything after is the message body.
+    if (args.size() < 2)
+    {
+        wolf::consolePrint("[AP] usage: ap say <text>  (e.g. \"ap say /help\")");
+        return;
+    }
+    if (!socket.isConnected())
+    {
+        wolf::consolePrint("[AP] not connected; cannot send");
+        return;
+    }
+
+    std::string text;
+    for (size_t i = 1; i < args.size(); ++i)
+    {
+        if (i > 1)
+            text.push_back(' ');
+        text += args[i];
+    }
+    if (!socket.say(text))
+        wolf::consolePrint("[AP] say failed (check connection state)");
+}
+
+void cmdGive(RewardMan &rewardMan, ISocket &socket, const std::vector<std::string> &args)
+{
+    if (args.size() < 2)
+    {
+        wolf::consolePrint("[AP] usage: ap give <ap_item_id>  (decimal or 0xHEX)");
+        return;
+    }
+
+    int64_t itemId = 0;
+    if (!parseInt64(args[1], itemId))
+    {
+        wolf::consolePrintf("[AP] could not parse item id %s", args[1].c_str());
+        return;
+    }
+
+    // Resolve a friendly name through the socket if connected; fall back to a
+    // marker so logs are searchable.
+    std::string name = socket.isConnected() ? socket.getItemName(itemId, socket.getPlayerSlot()) : std::string{};
+    if (name.empty())
+        name = "console-grant";
+
+    // Route through the same queue the items_received handler uses, so the
+    // grant exercises RewardMan + the brush/game-item/event-flag dispatchers
+    // exactly as a real server delivery would.
+    rewardMan.queueReward(itemId, name, 0);
+    wolf::consolePrintf("[AP] queued reward 0x%llX (%s)", static_cast<unsigned long long>(itemId), name.c_str());
+}
+
+void cmdHelp()
+{
+    wolf::consolePrint("[AP] subcommands:");
+    wolf::consolePrint("[AP]   ap status               - print connection / slot info");
+    wolf::consolePrint("[AP]   ap say <text>           - send chat or server slash command (e.g. /help)");
+    wolf::consolePrint("[AP]   ap give <ap_item_id>    - locally queue a reward (decimal or 0xHEX)");
+}
+
+} // namespace
+
+void registerAll(ISocket &socket, RewardMan &rewardMan)
+{
+    wolf::addCommand(
+        "ap",
+        [&socket, &rewardMan](const std::vector<std::string> &args)
+        {
+            if (args.size() < 2)
+            {
+                cmdHelp();
+                return;
+            }
+            const std::string &sub = args[1];
+            // Reslice so handlers see args[0] = subcommand, matching the usual
+            // CommandHandler convention.
+            std::vector<std::string> subArgs(args.begin() + 1, args.end());
+
+            if (sub == "status")
+                cmdStatus(socket, subArgs);
+            else if (sub == "say")
+                cmdSay(socket, subArgs);
+            else if (sub == "give")
+                cmdGive(rewardMan, socket, subArgs);
+            else if (sub == "help")
+                cmdHelp();
+            else
+            {
+                wolf::consolePrintf("[AP] unknown subcommand '%s'", sub.c_str());
+                cmdHelp();
+            }
+        },
+        "Archipelago client commands. Try 'ap help'.");
+}
+
+} // namespace console_commands

--- a/src/okami-apclient/console_commands.h
+++ b/src/okami-apclient/console_commands.h
@@ -1,0 +1,15 @@
+#pragma once
+
+class ISocket;
+class RewardMan;
+
+namespace console_commands
+{
+
+/// Register the AP-related developer console commands with WOLF.
+/// Idempotent; safe to call once during late init. Lifetime of socket and
+/// rewardMan must outlast the registration (currently both are owned for the
+/// duration of the mod).
+void registerAll(ISocket &socket, RewardMan &rewardMan);
+
+} // namespace console_commands

--- a/src/okami-apclient/isocket.h
+++ b/src/okami-apclient/isocket.h
@@ -38,6 +38,15 @@ class ISocket
     virtual void poll() = 0;
     virtual void processMainThreadTasks() = 0;
 
+    /**
+     * @brief Send a chat / slash-command message to the AP server.
+     *
+     * Server-side slash commands (e.g. "/help", "/players", "/missing") arrive
+     * in the same Say packet as plain chat -- the server distinguishes by the
+     * leading "/". Returns false if not connected; the message is dropped.
+     */
+    virtual bool say(const std::string &text) = 0;
+
     // Information queries
     virtual std::string getItemName(int64_t id, int player) const = 0;
     virtual std::string getItemDesc(int player) const = 0;

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -6,6 +6,7 @@
 
 #include "archipelagosocket.h"
 #include "checkman.h"
+#include "console_commands.h"
 #include "gamestate_accessors.hpp"
 #include "itempatch.hpp"
 #include "rewardman.h"
@@ -120,6 +121,11 @@ class APClientMod
 
         // Initialize check manager (sets up monitors and container hooks)
         g_checkMan->initialize();
+
+        // Register developer-console commands ("ap status", "ap say <...>",
+        // "ap give <id>"). Done after managers exist so the handlers can
+        // close over live references.
+        console_commands::registerAll(ArchipelagoSocket::instance(), *g_rewardMan);
 
         // Wire auto-save: queue save after each check is sent
         g_checkMan->setOnCheckSentCallback(

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -6,6 +6,7 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/checks/containers.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/checks/gamestate_monitors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/checks/shops.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/console_commands.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data/blowfish.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data/customiconpkg.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data/custommodelpkg.cpp

--- a/tests/mocks/mock_archipelagosocket.cpp
+++ b/tests/mocks/mock_archipelagosocket.cpp
@@ -58,6 +58,19 @@ void MockArchipelagoSocket::gameFinished()
     }
 }
 
+bool MockArchipelagoSocket::say(const std::string &text)
+{
+    if (state_ != ConnectionState::Connected)
+        return false;
+    saidMessages_.push_back(text);
+    return true;
+}
+
+const std::vector<std::string> &MockArchipelagoSocket::getSaidMessages() const
+{
+    return saidMessages_;
+}
+
 void MockArchipelagoSocket::poll()
 {
     pollCount_++;

--- a/tests/mocks/mock_archipelagosocket.h
+++ b/tests/mocks/mock_archipelagosocket.h
@@ -70,6 +70,7 @@ class MockArchipelagoSocket : public ISocket
     void gameFinished() override;
     void poll() override;
     void processMainThreadTasks() override;
+    bool say(const std::string &text) override;
 
     std::string getItemName(int64_t id, int player) const override;
     std::string getItemDesc(int player) const override;
@@ -108,6 +109,8 @@ class MockArchipelagoSocket : public ISocket
     const std::vector<int> &getStatusUpdates() const;
 
     bool wasGameFinishedCalled() const;
+
+    const std::vector<std::string> &getSaidMessages() const;
 
     size_t getScoutRequestCount() const;
     const SentScoutRequest &getScoutRequest(size_t index) const;
@@ -177,6 +180,7 @@ class MockArchipelagoSocket : public ISocket
     std::vector<int64_t> sentLocations_;
     std::vector<int> statusUpdates_;
     std::vector<SentScoutRequest> scoutRequests_;
+    std::vector<std::string> saidMessages_;
     bool gameFinishedCalled_ = false;
 
     // Item delivery


### PR DESCRIPTION
Registers ap status / ap say <text> / ap give <ap_item_id> with WOLF's command registry. say() routes to APClient::Say so server slash commands like /help reach the server, and give() queues through RewardMan to exercise the real grant path. PrintJSON output is mirrored to the console so server replies are scrollable history.

Resolves #102, #119 