### PR TITLE
Fix/warp engine call

### DIFF
--- a/include/okami/warp.hpp
+++ b/include/okami/warp.hpp
@@ -6,16 +6,18 @@
 namespace okami
 {
 
-/// Warp data structure at main.dll+0xB65E64 (20 bytes)
-/// Used to set the destination for map transitions
+/// Warp data structure at main.dll+0xB65E64 (20 bytes).
+/// Used to set the destination for map transitions.
 struct WarpData
 {
     float x;               // +0x00: Target X coordinate
     float y;               // +0x04: Target Y coordinate
     float z;               // +0x08: Target Z coordinate
-    float facingDirection; // +0x0C: Target facing angle
+    float facingDirection; // +0x0C: Target facing angle (radians)
     uint16_t mapID;        // +0x10: Target map ID
-    uint8_t jumpID;        // +0x12: Loading zone ID (0xFF = use map default spawn)
+    uint8_t jumpID;        // +0x12: Loading-zone ID. 0xFF means "use the X/Y/Z above";
+                           //        any other value picks loading zone N on the target map and
+                           //        uses that zone's stored coords (X/Y/Z above are ignored).
     uint8_t flipCamera;    // +0x13: Interior loading zone ID
     uint32_t unknown;      // +0x14: Unknown purpose (possibly padding or reserved)
 };
@@ -177,11 +179,24 @@ inline const std::vector<Category> AllCategories = {
 
 namespace main
 {
-/// Warp data structure address
+/// Engine warp-data buffer base. Our WarpData struct begins at +4 of this
+/// (the X coordinate); the leading 4 bytes and trailing 4 bytes (+0x18..+0x1B
+/// is our `unknown`; +0x1C..+0x1F is engine-only) are engine state we don't
+/// model. Don't memset past the struct.
+constexpr uintptr_t warpDataBuffer = 0xB65E60;
+
+/// Address of the WarpData struct within the engine buffer (= warpDataBuffer + 4).
 constexpr uintptr_t warpData = 0xB65E64;
 
-/// Map load trigger flag address (bit 1 triggers warp)
-constexpr uintptr_t mapLoadFlags = 0xB6B2AF;
+/// Engine warp-trigger function. Reads the warp buffer that the caller has
+/// already populated and fires the map load with all the bookkeeping the
+/// engine itself relies on: sets the trigger bit at 0xB6B2AC bit 25, sets
+/// the area-load flags at 0xB6B2A0 (mask 0x6001000), and runs the screen-
+/// fade / overlay setup. Honors the buffer's jumpID, so this works for both
+/// "use caller-supplied X/Y/Z" (jumpID=0xFF) and "use loading zone N on the
+/// target map" (jumpID != 0xFF) cases. Decompiled signature:
+///   void(longlong buffer)
+constexpr uintptr_t triggerWarpFn = 0x489770;
 } // namespace main
 
 } // namespace okami

--- a/include/okami/warp_entries.hpp
+++ b/include/okami/warp_entries.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+// Auto-generated from the game's per-map JMP loading-zone tables (one
+// canonical entry-point per destination map, picked across all source maps).
+// The Okami HD Steam binary hasn't shipped a content patch since 2017, so
+// these values are fixed; do not edit by hand.
+
+namespace okami::warp
+{
+
+/// One valid entry-point for a destination map, lifted from the engine's own
+/// per-map JMP table. Coordinates are in the game's world-space units; facing
+/// is stored in degrees (multiply by pi/180 to match
+/// WarpData::facingDirection).
+struct EntryCoords
+{
+    std::uint16_t mapID;
+    std::int16_t x;
+    std::int16_t y;
+    std::int16_t z;
+    std::int16_t facingDeg;
+};
+
+/// Sorted by mapID. 84 entries covering every destination map referenced
+/// by any source map's JMP table.
+inline constexpr EntryCoords kEntryCoords[] = {
+    {0x0100, -1, -5017, 5158, 0},       // src=0x0122 key=0x00
+    {0x0101, 2900, 248, -5090, -155},   // src=0x0122 key=0x01
+    {0x0102, -1, 184, -1211, 0},        // src=0x0122 key=0x02
+    {0x0103, -58, -48, 309, 162},       // src=0x0F01 key=0x02
+    {0x0104, 0, -4769, -2790, 0},       // src=0x0106 key=0x00
+    {0x0105, 1353, 51, 22, -90},        // src=0x0F07 key=0x01
+    {0x0106, -965, 3047, -7948, 180},   // src=0x0104 key=0x01
+    {0x0107, 8170, -10000, 10100, 90},  // src=0x0108 key=0x00
+    {0x0108, -5080, 711, 1830, 90},     // src=0x0107 key=0x00
+    {0x0109, 1131, 49, -1527, -13},     // src=0x010B key=0x00
+    {0x010A, 0, 1, -48, 180},           // src=0x0F03 key=0x02
+    {0x010B, 0, 0, 20, 0},              // src=0x0109 key=0x05
+    {0x010C, 0, 7, -58, -180},          // src=0x0F02 key=0x09
+    {0x010D, -3650, 200, -1300, -90},   // src=0x0107 key=0x03
+    {0x010E, -26, 0, 1413, 0},          // src=0x0110 key=0x00
+    {0x0110, 0, -19, 1173, -170},       // src=0x010E key=0x00
+    {0x0111, 0, 0, 0, 0},               // src=0x010E key=0x01
+    {0x0112, 2403, -324, 2990, -155},   // src=0x0111 key=0x01
+    {0x0113, -1043, 2501, -8707, 180},  // src=0x0F0A key=0x0A
+    {0x0114, 0, 31, -170, 180},         // src=0x0F08 key=0x08
+    {0x0115, 0, 31, -170, -180},        // src=0x0F12 key=0x05
+    {0x0116, 0, 31, -170, -180},        // src=0x0F0C key=0x05
+    {0x0117, 0, 31, -170, -180},        // src=0x0F0C key=0x06
+    {0x0118, 0, 31, -170, -180},        // src=0x0F13 key=0x05
+    {0x0119, 0, 27, -28, 180},          // src=0x0F12 key=0x07
+    {0x011A, -1043, 2501, -8707, 180},  // src=0x0F0C key=0x0B
+    {0x011B, -1043, 2501, -8707, 180},  // src=0x0F12 key=0x08
+    {0x011C, 0, 31, -170, -180},        // src=0x0203 key=0x13
+    {0x011D, 0, 31, -170, -180},        // src=0x0F0C key=0x0D
+    {0x0122, -13, -26, 238, -178},      // src=0x0100 key=0x00
+    {0x0200, 0, 671, 1850, -180},       // src=0x0201 key=0x01
+    {0x0201, -1009, -255, -830, 90},    // src=0x010B key=0x03
+    {0x0202, 0, 0, 0, 0},               // src=0x0200 key=0x01
+    {0x0203, 1166, 77, -1506, -110},    // src=0x010B key=0x02
+    {0x0204, 0, -50, 0, 180},           // src=0x0203 key=0x11
+    {0x0205, -1060, -34, 390, 120},     // src=0x0F0A key=0x04
+    {0x0206, 0, 16, 231, 180},          // src=0x0200 key=0x02
+    {0x0207, 735, -13, -1721, 180},     // src=0x0206 key=0x04
+    {0x0208, 0, 0, -100, 180},          // src=0x020D key=0x01
+    {0x0209, 0, -437, 1285, 0},         // src=0x020E key=0x01
+    {0x020A, -88, 4, 668, 167},         // src=0x0F0C key=0x02
+    {0x020B, 0, 0, 0, 0},               // src=0x0206 key=0x03
+    {0x020C, 55, 0, 0, 0},              // src=0x0201 key=0x07
+    {0x020D, 8, 300, 786, 0},           // src=0x0208 key=0x00
+    {0x020E, 0, 691, 560, 180},         // src=0x0209 key=0x00
+    {0x020F, -4811, -4996, -5422, -90}, // src=0x0208 key=0x04
+    {0x0301, -120, 270, -1539, -21},    // src=0x0313 key=0x00
+    {0x0302, 0, 208, -1540, 0},         // src=0x0311 key=0x03
+    {0x0303, -3504, 4883, -1367, 180},  // src=0x0304 key=0x00
+    {0x0304, 0, -61, -897, 0},          // src=0x0303 key=0x0D
+    {0x0305, -805, 1413, 313, 77},      // src=0x030D key=0x00
+    {0x0306, -2, -714, 3463, -180},     // src=0x0311 key=0x0D
+    {0x0307, -591, -39, 3321, 169},     // src=0x0308 key=0x00
+    {0x0308, -1008, 2501, -8700, -178}, // src=0x0307 key=0x03
+    {0x0309, -7, 16, 503, 178},         // src=0x0307 key=0x04
+    {0x030A, -179, 0, -60, 80},         // src=0x0307 key=0x05
+    {0x030B, 0, 2, 424, 180},           // src=0x0307 key=0x01
+    {0x030C, -4002, 186, -1315, -90},   // src=0x0307 key=0x02
+    {0x030D, 0, 3, 35, 180},            // src=0x0305 key=0x07
+    {0x0310, -862, 798, -15424, -168},  // src=0x0305 key=0x00
+    {0x0311, -910, 797, -15411, 11},    // src=0x0302 key=0x01
+    {0x0312, 0, 4, -300, 0},            // src=0x0307 key=0x06
+    {0x0313, 6, 0, -427, 0},            // src=0x0301 key=0x02
+    {0x0314, 0, 1, 0, 0},               // src=0x0303 key=0x0E
+    {0x0E00, 0, 0, 0, 0},               // src=0x0200 key=0x13
+    {0x0E01, 0, 0, 0, 0},               // src=0x0200 key=0x14
+    {0x0E02, 0, 0, -10, 0},             // src=0x0F04 key=0x09
+    {0x0E03, 0, 0, 0, 0},               // src=0x0F12 key=0x04
+    {0x0E04, 0, 0, 0, 0},               // src=0x0F0C key=0x0C
+    {0x0F01, -1521, -222, -765, 50},    // src=0x0102 key=0x00
+    {0x0F02, -1521, -222, -765, 50},    // src=0x0102 key=0x01
+    {0x0F03, -2386, 106, 3416, 89},     // src=0x010A key=0x00
+    {0x0F04, 913, 0, 7414, -127},       // src=0x0104 key=0x00
+    {0x0F06, 1800, 18077, 9850, 180},   // src=0x0110 key=0x02
+    {0x0F07, -8280, 1042, 3220, 90},    // src=0x0105 key=0x02
+    {0x0F08, -8280, 1042, 3220, 90},    // src=0x0105 key=0x03
+    {0x0F09, 3383, 415, 1702, -77},     // src=0x0105 key=0x00
+    {0x0F0A, 3383, 415, 1702, -77},     // src=0x0105 key=0x01
+    {0x0F0C, 2251, -236, -12918, 178},  // src=0x0116 key=0x00
+    {0x0F11, 1977, -9754, -2675, 0},    // src=0x0F02 key=0x08
+    {0x0F12, 3004, -9998, 435, 180},    // src=0x010C key=0x02
+    {0x0F13, -2714, 442, -3780, 0},     // src=0x0118 key=0x00
+    {0x0F20, -1521, -222, -765, 50},    // src=0x0302 key=0x00
+    {0x0F21, 1782, 18300, 5378, 0},     // src=0x0306 key=0x00
+};
+
+/// Look up the canonical entry coords for a destination map. Returns
+/// std::nullopt if the map ID is not present in any JMP table.
+[[nodiscard]] constexpr std::optional<EntryCoords> lookupEntry(std::uint16_t mapID) noexcept
+{
+    for (const auto &e : kEntryCoords)
+    {
+        if (e.mapID == mapID)
+        {
+            return e;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace okami::warp

--- a/src/okami-apclient/gamestate_accessors.cpp
+++ b/src/okami-apclient/gamestate_accessors.cpp
@@ -17,10 +17,6 @@ Accessor<okami::CollectionData> collectionData;
 Accessor<okami::WorldStateData> worldStateData;
 Accessor<okami::TrackerData> trackerData;
 
-// Warp system accessors
-Accessor<okami::WarpData> warpData;
-Accessor<uint8_t> mapLoadFlags;
-
 // Item parameter table accessor
 Accessor<std::array<okami::ItemParam, okami::ItemTypes::NUM_ITEM_TYPES>> itemParams;
 
@@ -53,10 +49,6 @@ void initialize()
 
     // Brush upgrades from TrackerData
     brushUpgrades = BitFieldAccessor<32>("main.dll", trackerDataAddr + offsetof(okami::TrackerData, brushUpgrades));
-
-    // Warp system accessors
-    warpData = Accessor<okami::WarpData>("main.dll", okami::main::warpData);
-    mapLoadFlags = Accessor<uint8_t>("main.dll", okami::main::mapLoadFlags);
 
     // Item parameter table
     constexpr uintptr_t itemParamsAddr = 0x7AB220;

--- a/src/okami-apclient/gamestate_accessors.hpp
+++ b/src/okami-apclient/gamestate_accessors.hpp
@@ -32,10 +32,6 @@ extern Accessor<okami::CollectionData> collectionData;
 extern Accessor<okami::WorldStateData> worldStateData;
 extern Accessor<okami::TrackerData> trackerData;
 
-// Warp system accessors
-extern Accessor<okami::WarpData> warpData;
-extern Accessor<uint8_t> mapLoadFlags;
-
 // Item parameter table accessor
 extern Accessor<std::array<okami::ItemParam, okami::ItemTypes::NUM_ITEM_TYPES>> itemParams;
 

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -111,7 +111,7 @@ class APClientMod
         initializeGui();
         loginwindow::initialize(ArchipelagoSocket::instance());
         loginwindow::setSaveMan(g_saveMan.get());
-        warpwindow::initialize();
+        warpwindow::initialize(*g_checkMan);
 
         g_checkMan->initialize();
 

--- a/src/okami-apclient/ui/warpwindow.cpp
+++ b/src/okami-apclient/ui/warpwindow.cpp
@@ -2,10 +2,12 @@
 
 #include <algorithm>
 #include <cstring>
+#include <numbers>
 #include <string>
 
 #include <okami/maps.hpp>
 #include <okami/warp.hpp>
+#include <okami/warp_entries.hpp>
 #include <wolf_framework.hpp>
 
 #include "../checkman.h"
@@ -59,7 +61,7 @@ static void renderCurrentMap();
 static void renderPresetSelection();
 static void renderManualCoordinates();
 static void renderWarpButton();
-static void executeWarp(const okami::WarpData &data);
+static void executeWarp(const okami::WarpData &data, bool useJmpOverride);
 
 void initialize(CheckMan &checkMan)
 {
@@ -213,7 +215,7 @@ static void renderManualCoordinates()
                                     static_cast<uint8_t>(g_manualJumpID),
                                     static_cast<uint8_t>(g_manualFlipCamera),
                                     0};
-            executeWarp(data);
+            executeWarp(data, /*useJmpOverride=*/false);
         }
 
         // Button to copy selected preset to manual fields
@@ -256,7 +258,7 @@ static void renderWarpButton()
         if (canWarp)
         {
             const auto &preset = (*presets)[g_selectedPreset];
-            executeWarp(preset.data);
+            executeWarp(preset.data, /*useJmpOverride=*/true);
         }
     }
 
@@ -267,19 +269,17 @@ static void renderWarpButton()
 #endif
 }
 
-static void executeWarp(const okami::WarpData &data)
+static void executeWarp(const okami::WarpData &data, bool useJmpOverride)
 {
     // Write the warp fields ourselves and fire the engine's own trigger
-    // function. The legacy path set bit 1 at 0xB6B2AF directly; that's the
-    // same bit the engine's trigger sets, but the engine's trigger ALSO sets
-    // the area-load flags at 0xB6B2A0 (mask 0x6001000) and runs the
-    // screen-fade / overlay setup. Skipping that bookkeeping caused visual
-    // and state glitches downstream.
+    // function. The trigger sets the area-load flags at 0xB6B2A0 and runs
+    // the screen-fade / overlay setup that a bare bit-poke skipped.
     //
-    // Writing the buffer ourselves (rather than going through the engine's
-    // "warp to coords" populator at 0x489160) keeps the caller-supplied
-    // jumpID intact, so non-0xFF entries continue to use their loading zone
-    // on the target map.
+    // Preset warps pass useJmpOverride=true: replace the preset's coords
+    // with the engine's own canonical entry coords (sourced from the per-map
+    // JMP tables, see warp_entries.hpp) so every preset lands inside
+    // walkable geometry. Manual coord entries pass false to honour exactly
+    // what the user typed.
     const uintptr_t base = wolf::getModuleBase("main.dll");
     if (base == 0)
     {
@@ -287,8 +287,19 @@ static void executeWarp(const okami::WarpData &data)
         return;
     }
 
+    okami::WarpData resolved = data;
+    const auto entry = useJmpOverride ? okami::warp::lookupEntry(data.mapID) : std::nullopt;
+    if (entry)
+    {
+        resolved.x = static_cast<float>(entry->x);
+        resolved.y = static_cast<float>(entry->y);
+        resolved.z = static_cast<float>(entry->z);
+        resolved.facingDirection = static_cast<float>(entry->facingDeg) * (std::numbers::pi_v<float> / 180.0f);
+        resolved.jumpID = 0xFF;
+    }
+
     auto *warpPtr = reinterpret_cast<okami::WarpData *>(base + okami::main::warpData);
-    *warpPtr = data;
+    *warpPtr = resolved;
 
     // Suppress check sending across the warp transition. The map's init
     // flips state bits (brushes, world-state, etc.) that look like
@@ -303,7 +314,7 @@ static void executeWarp(const okami::WarpData &data)
     auto *buffer = reinterpret_cast<void *>(base + okami::main::warpDataBuffer);
     trigger(buffer);
 
-    wolf::logInfo("[Warp] Initiated warp to map 0x%04X (jumpID=0x%02X) at (%.1f, %.1f, %.1f)", data.mapID, data.jumpID, data.x, data.y, data.z);
+    wolf::logInfo("[Warp] Initiated warp to map 0x%04X at (%.1f, %.1f, %.1f)", resolved.mapID, resolved.x, resolved.y, resolved.z);
 }
 
 } // namespace warpwindow

--- a/src/okami-apclient/ui/warpwindow.cpp
+++ b/src/okami-apclient/ui/warpwindow.cpp
@@ -16,8 +16,9 @@
 
 namespace
 {
-// Game Memory Constants (cross-platform)
-constexpr uint8_t WARP_TRIGGER_FLAG = 0x02;
+// Engine warp-trigger function. Reads the already-populated warp buffer and
+// fires the map load with the area-load / fade bookkeeping.
+using TriggerWarpFn = void (*)(void *buffer);
 
 #ifdef _WIN32
 // UI Layout Constants (Windows-only, used in ImGui code)
@@ -265,28 +266,32 @@ static void renderWarpButton()
 
 static void executeWarp(const okami::WarpData &data)
 {
-    // Write warp data to game memory using direct pointer access
-    okami::WarpData *warpPtr = apgame::warpData.get_ptr();
-    if (!warpPtr)
+    // Write the warp fields ourselves and fire the engine's own trigger
+    // function. The legacy path set bit 1 at 0xB6B2AF directly; that's the
+    // same bit the engine's trigger sets, but the engine's trigger ALSO sets
+    // the area-load flags at 0xB6B2A0 (mask 0x6001000) and runs the
+    // screen-fade / overlay setup. Skipping that bookkeeping caused visual
+    // and state glitches downstream.
+    //
+    // Writing the buffer ourselves (rather than going through the engine's
+    // "warp to coords" populator at 0x489160) keeps the caller-supplied
+    // jumpID intact, so non-0xFF entries continue to use their loading zone
+    // on the target map.
+    const uintptr_t base = wolf::getModuleBase("main.dll");
+    if (base == 0)
     {
-        wolf::logError("[Warp] Failed to get warp data pointer");
+        wolf::logError("[Warp] main.dll base unavailable");
         return;
     }
 
-    uint8_t *flagsPtr = apgame::mapLoadFlags.get_ptr();
-    if (!flagsPtr)
-    {
-        wolf::logError("[Warp] Failed to get map load flags pointer");
-        return;
-    }
-
+    auto *warpPtr = reinterpret_cast<okami::WarpData *>(base + okami::main::warpData);
     *warpPtr = data;
 
-    // Set the trigger bit to initiate warp
-    // Bit 1 (value 0x02) triggers the warp
-    *flagsPtr |= WARP_TRIGGER_FLAG;
+    auto trigger = reinterpret_cast<TriggerWarpFn>(base + okami::main::triggerWarpFn);
+    auto *buffer = reinterpret_cast<void *>(base + okami::main::warpDataBuffer);
+    trigger(buffer);
 
-    wolf::logInfo("[Warp] Initiated warp to map 0x%04X at (%.1f, %.1f, %.1f)", data.mapID, data.x, data.y, data.z);
+    wolf::logInfo("[Warp] Initiated warp to map 0x%04X (jumpID=0x%02X) at (%.1f, %.1f, %.1f)", data.mapID, data.jumpID, data.x, data.y, data.z);
 }
 
 } // namespace warpwindow

--- a/src/okami-apclient/ui/warpwindow.cpp
+++ b/src/okami-apclient/ui/warpwindow.cpp
@@ -8,6 +8,7 @@
 #include <okami/warp.hpp>
 #include <wolf_framework.hpp>
 
+#include "../checkman.h"
 #include "../gamestate_accessors.hpp"
 
 #ifdef _WIN32
@@ -39,6 +40,7 @@ constexpr int MAX_FLIP_CAMERA = 0xFF;
 static bool g_visible = false;
 static size_t g_selectedCategory = 0;
 static size_t g_selectedPreset = 0;
+static CheckMan *g_checkMan = nullptr;
 
 // Manual coordinate entry (for custom warps)
 static float g_manualX = 0.0f;
@@ -59,11 +61,12 @@ static void renderManualCoordinates();
 static void renderWarpButton();
 static void executeWarp(const okami::WarpData &data);
 
-void initialize()
+void initialize(CheckMan &checkMan)
 {
     g_visible = false;
     g_selectedCategory = 0;
     g_selectedPreset = 0;
+    g_checkMan = &checkMan;
 
     wolf::addCommand("warps", []([[maybe_unused]] const std::vector<std::string> &args) { g_visible = true; }, "Enable the warps menu");
 }
@@ -286,6 +289,15 @@ static void executeWarp(const okami::WarpData &data)
 
     auto *warpPtr = reinterpret_cast<okami::WarpData *>(base + okami::main::warpData);
     *warpPtr = data;
+
+    // Suppress check sending across the warp transition. The map's init
+    // flips state bits (brushes, world-state, etc.) that look like
+    // legitimate 0->1 transitions to our monitors, but they're not real
+    // gameplay events. The post-load onPlayStart re-enables sending.
+    if (g_checkMan)
+    {
+        g_checkMan->enableSending(false);
+    }
 
     auto trigger = reinterpret_cast<TriggerWarpFn>(base + okami::main::triggerWarpFn);
     auto *buffer = reinterpret_cast<void *>(base + okami::main::warpDataBuffer);

--- a/src/okami-apclient/ui/warpwindow.h
+++ b/src/okami-apclient/ui/warpwindow.h
@@ -4,15 +4,19 @@
 #define NOMINMAX
 #endif
 
+class CheckMan;
+
 namespace warpwindow
 {
 
 /**
  * @brief Initialize Warp Window state
  *
- * Call this once during mod initialization.
+ * Call this once during mod initialization. The CheckMan reference is
+ * used to suppress check sending during a warp transition; the post-load
+ * onPlayStart callback re-enables sending automatically.
  */
-void initialize();
+void initialize(CheckMan &checkMan);
 
 /**
  * @brief Cleanup Warp Window resources


### PR DESCRIPTION
## Description
Overhauls how map warps work

## Changes
- Use the engine's JMP tables for preset warp coords
- Suppress check sending across warp transitions
- Route warps through the engine's trigger function
