### PR TITLE
Cave of Nagi softlock fix and event-trigger documentation

### DIFF
--- a/docs/event-triggers-runtime.md
+++ b/docs/event-triggers-runtime.md
@@ -1,0 +1,250 @@
+# Event triggers: runtime dispatch
+
+The companion to [event-triggers.md](event-triggers.md), which describes the static SCA format on disk. This doc covers the runtime side: the per-stage TICK function, the state-bit dispatcher that fires stage-specific callbacks, and the patterns we figured out while bypassing Cave of Nagi's forced-tutorial softlock for AP randomization.
+
+The descriptions here are concrete to Okami HD as analyzed via Ghidra; addresses use Ghidra's image-base convention (`0x180000000`). Where we say "main.dll +0xNNNNNN" the offset is module-relative.
+
+## The big picture
+
+Each stage has its own TICK function, called every frame from the main game loop. The TICK reads bits in a runtime "world-state" struct and dispatches stage-specific callbacks (cutscenes, tutorial steps, cleanup, etc.) when their gate bit is set and their anti-redispatch latch isn't. The callbacks run via the scheduler — they're not inline calls — so they get a scheduler frame and can do internal waits.
+
+The bits themselves are flipped by other code (other callbacks, scripts, SCA trigger volumes the player crosses, the entrance cutscene's master script, etc.). Scripts and trigger volumes cause cascading bit flips that drive the chain.
+
+## The world-state struct and bit encoding
+
+The state lives in a struct accessed through a **pointer** at `main.dll + 0xB205C0`, named `DAT_180b205c0` in Ghidra. **It is a pointer variable, not a struct base.** Ghidra's pseudo-C makes this ambiguous — `DAT_180b205c0 + 0x39C` looks like field arithmetic but actually means "dereference the pointer and add `0x39C`".
+
+To read state bits in mod code:
+
+```cpp
+auto worldStateBase = *reinterpret_cast<uintptr_t *>(mainBase + 0xB205C0);
+auto bits = *reinterpret_cast<uint32_t *>(worldStateBase + 0x39C);
+```
+
+Reading `mainBase + 0xB205C0 + 0x39C` directly returns the uninitialized bytes of the pointer variable — always zero in our binary, which silently breaks any state polling that uses that address.
+
+The per-stage state-bit setter is `FUN_180170830(uint32_t enc)`, paired with a clear-bit version `FUN_1801707c0(uint32_t enc)`. Both encode the target as:
+
+```
+addr = worldStateBase + (high16 * 0x20) + 0x35C + (low16/32) * 4
+mask = 0x80000000 >> (low16 % 32)        // big-endian within the word
+```
+
+So `FUN_180170830(0x2001b)` (high16=2, low16=27) writes to `worldStateBase + 0x39C` with mask `0x10`. The big-endian bit numbering matches the in-game `okami::BitField<N>` convention.
+
+The state struct is laid out as multiple sub-blocks of `0x20` bytes each, starting at `+0x35C`. For Cave of Nagi we mostly care about offsets `+0x39C` and `+0x3A0` (the second sub-block).
+
+Heads-up on bitfield conventions: this state-bit setter and the engine's `okami::BitField<N>` both use big-endian-within-32-bit-word indexing. The brush "obtained" / "usable" bitfields manipulated by `FUN_18017c270` (`brushState+0x70` and `+0x78`) use the *opposite* convention: little-endian within a 64-bit word (`1ULL << bit`). The mod's `apgame::obtainedBrushesSource` reads them via byte-and-bit math accordingly. Don't transpose between the two.
+
+## The per-stage TICK
+
+Cave of Nagi's TICK is `FUN_1804c4300`. The version below is abridged to the entrance + constellation/kami section that the AP softlock fix touches. The real function continues with four more dispatch sections (gating `FUN_1804c30b0`, `FUN_1804c1050`, `FUN_1804c3c00`, `FUN_1804c3860`) that handle later CoN events; check Ghidra for the full body.
+
+```c
+if ((world+0x39C >> 0x1d) & 1) {
+    // entrance dispatch section (FUN_1804c1b10)
+    if (!(world+0x39C & 0x200) /* entrance latch, mask 0x200 */) {
+        if (FUN_1803f3380(ctx, 0, 0, 1) && !(GGS[0] & 0x40000000)) {
+            FUN_180170830(0x20009);  // entrance dispatch latch (+0x39C bit 9, mask 0x00400000)
+            FUN_1801707c0(0x5);      // clear +0x35C bit 5
+            FUN_1803f4900(ctx);
+            ret = FUN_1803ef3c0(ctx + 0x20, FUN_1804c1b10, 0xffffffff);
+            FUN_1803f3170(ctx, ret);
+        }
+    }
+    /* atomic clear of +0x39C bit 17 (mask 0x4000) */
+    if (FUN_1803f3380(ctx, 1, 0, 1)) FUN_180170830(0x20011);
+    if (!(world+0x3A0 & 0x400000)) FUN_1804c14a0();
+}
+if ((world+0x39C >> 0x1c) & 1) {
+    // constellation/kami/tutorial section
+    if ((world+0x3A0 & 0x400000) && !(world+0x39C & 0x400)) {
+        FUN_180170830(0x20015);  // FUN_1804c31c0 anti-redispatch latch
+        FUN_1803f4900(ctx);
+        ret = FUN_1803ef3c0(ctx + 0x20, FUN_1804c31c0, 0xffffffff);
+        FUN_1803f3170(ctx, ret);
+    }
+    FUN_1804c1900();   // constellation puzzle handler
+    if (!(world+0x39C & 0x200) && (world+0x3A0 & 0x200000)) {
+        FUN_180170830(0x20016);
+        FUN_1803f4900(ctx);
+        ret = FUN_1803ef3c0(ctx + 0x20, FUN_1804c1f50, 0xffffffff);
+        FUN_1803f3170(ctx, ret);
+    }
+    FUN_1804c1130();   // inner TICK for input + later dispatch gates
+    FUN_1804c1820();
+}
+// ... further sections for FUN_1804c30b0, FUN_1804c1050, etc.
+```
+
+Two patterns matter here.
+
+### Pattern 1: gate + anti-redispatch latch + dispatch
+
+Most callback dispatches follow the same shape:
+
+```c
+if (GATE_BIT_SET && !LATCH_BIT_SET) {
+    FUN_180170830(LATCH_ENC);                      // set the latch
+    FUN_1803f4900(ctx);                            // enter cutscene mode
+    ret = FUN_1803ef3c0(ctx + 0x20, callback, ~0); // schedule the callback
+    FUN_1803f3170(ctx, ret);                       // register it
+}
+```
+
+The latch is what makes a one-shot of an otherwise per-tick check. `FUN_1803f4900` sets a bunch of bits (see below) before scheduling, so the callback runs in "cutscene mode."
+
+Pattern variant: a few dispatch sites omit the latch entirely. The clearest example is `FUN_1804c1130`'s third clause (the `FUN_1804c2560` post-tutorial-cleanup dispatch), which fires every tick that bit 29 of `+0x39C` is set. The callback itself must clear the gate before yielding, or the scheduler must dedupe pending dispatches; either way, the "every dispatch follows the same shape" rule has exceptions, and you should read the actual TICK before assuming a latch will be there.
+
+### Pattern 2: cutscene-mode entry/exit
+
+`FUN_1803f4900` does:
+
+```
+AreaLoadFlags (main.dll+0xB6B2A0) |= 0x02802000   // letterbox + scene
+GGS[0]        (main.dll+0xB6B2AC) |= 0x40000040   // cutscene mode
+GGS[2]        (main.dll+0xB6B2B4) &= ~0x01000000  // ENABLES player input (yes, really)
+```
+
+The opposite is `FUN_1803f4730(ctx, 0)`, which clears roughly the same `AreaLoadFlags` and `GGS[0]` bits. It is *not* a precise inverse: it clears `GGS[0] & ~0x40000042` (an extra bit 1) and `AreaLoadFlags & ~0x00802000` unconditionally with `~0x02000000` cleared only when `GGS[0] & 0x02000000` is already clear. For bypass purposes, replicating the exact `FUN_1803f4900` masks is what you actually need; don't try to mirror `FUN_1803f4730` byte-for-byte. The standard wrapper `FUN_1803f48d0(ctx, 1)` calls `FUN_1803f4730` and then `FUN_1804561d0(*(ctx+0x30))` (a scheduler-frame release).
+
+The camera entity reads these bits to decide whether to stay in its cutscene pose or follow the player. Bypass code that leaves the bits set keeps the camera stuck.
+
+## The scheduler-frame caveat
+
+Callbacks scheduled via `FUN_1803ef3c0(ctx + 0x20, fn, flags)` receive a scheduler frame at `ctx + 0x30` that they use for their internal waits (`FUN_1803f5170`, `FUN_1804567c0`). **A direct call to such a callback — bypassing `FUN_1803ef3c0` — crashes** as soon as the callback dereferences `ctx + 0x30`, because either (a) the field is null/stale or (b) it points at an old scheduler frame from a different callback's lifetime.
+
+If you need to dispatch a callback from outside the natural chain, replicate the scheduler dance instead of calling the function directly:
+
+```cpp
+auto fnSchedule = (ScheduleCbFn)(mainBase + 0x3EF3C0);
+auto fnRegister = (RegisterCbFn)(mainBase + 0x3F3170);
+uint32_t ret = fnSchedule(ctx + 0x20, callbackPtr, 0xFFFFFFFFU);
+fnRegister(ctx, ret);
+```
+
+The callback runs on the next scheduler pass with a proper frame. Internal waits pump correctly. This is how you "force-fire" an event without triggering the natural gate chain.
+
+## Inlining pitfalls (unverified)
+
+Small wrapper functions are inline candidates and may not show up as call targets in every caller. The original observation here was that a hook on `FUN_1803f35f0` produced zero `schedule_script` events for scripts queued from `FUN_1804c1f50` (e.g. CoN's tutorial script `0x1010`), but static analysis disagrees: Ghidra shows `FUN_1804c1f50` at `0x1804c224b` has an `UNCONDITIONAL_CALL` to `FUN_1803f35f0`, and the decompiled body contains a literal `FUN_1803f35f0(ctx, 0x1010, ...)` call site. 
+
+## The skip-the-first-link pattern
+
+When a callback chain has multiple stages — cutscene → puzzle → dialog → tutorial → cleanup — you can in theory hook any of them. In practice, hooking anything but the first one usually fails, because by then:
+
+- The camera has been switched to a special cutscene pose.
+- Cutscene-mode bits are set across multiple addresses.
+- One or more scripts have started executing concurrently, holding scheduler resources.
+- Internal counters (`ctx+4`, `ctx+8`, ...) have been initialized.
+
+Reversing all of that mid-chain requires either calling the natural cleanup function (which has scheduler dependencies that don't hold outside its expected context) or replicating its bit operations by hand (which we couldn't get right without missing some entity-level state).
+
+The clean fix is to hook the **first** callback in the chain and replace it with a stub that:
+
+1. Clears the cutscene-mode bits the dispatcher's `FUN_1803f4900` pre-call set.
+2. Replicates the one essential side-effect we still need (in CoN's case, granting the brush bit so `BrushMan` fires the AP check).
+3. Returns without calling the original — none of the downstream dispatches happen because their gate bits never get set.
+
+The entrance-hook on `FUN_1804c1b10` works precisely because it's the first link. The same idiom applied to `FUN_1804c31c0` (statue rejuv → constellation → ...) skipped the entire CoN forced-tutorial chain in one move, after multiple iterations trying to bypass `FUN_1804c1f50` (the middle of the chain) had failed.
+
+## Cave of Nagi callback chain (reference)
+
+Confirmed offsets and dispatch order:
+
+| Function        | Offset      | Role                                                                                                                                                  |
+| --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FUN_1804c4300` | `+0x4C4300` | per-stage TICK (outer dispatcher)                                                                                                                     |
+| `FUN_1804c1b10` | `+0x4C1B10` | entrance cutscene (camera lower + portcullis fall + script `0x1003`)                                                                                  |
+| `FUN_1804c31c0` | `+0x4C31C0` | statue rejuv: brush bit `0xC` via `FUN_18017c270`, constellation puzzle                                                                               |
+| `FUN_1804c1900` | `+0x4C1900` | constellation puzzle handler (per-tick, increments `ctx+4`)                                                                                           |
+| `FUN_1804c1f50` | `+0x4C1F50` | kami dialog + forced rock-slash tutorial (script `0x1010`)                                                                                            |
+| `FUN_1804c1130` | `+0x4C1130` | inner TICK (rock-slash input check, dispatches `FUN_1804c28d0` and `FUN_1804c2560` based on `+0x39C` bits)                                            |
+| `FUN_1804c28d0` | `+0x4C28D0` | rock-slash callback (player slashed: schedules script `0x1012` rock break)                                                                            |
+| `FUN_1804c2560` | `+0x4C2560` | post-tutorial cleanup (kami leaves, area unblocks)                                                                                                    |
+| `FUN_1804c2770` | `+0x4C2770` | camera-reset cleanup (called from `FUN_1804c2560` epilogue: clears letterbox, calls `FUN_180152200(camera, 2, 2, ...)` to switch back to follow mode) |
+| `FUN_1803f4900` | `+0x3F4900` | enter cutscene mode (called by dispatcher pre-call)                                                                                                   |
+| `FUN_1803f4730` | `+0x3F4730` | exit cutscene mode (clears bits set by `FUN_1803f4900`)                                                                                               |
+| `FUN_1803f48d0` | `+0x3F48D0` | wrapper: `FUN_1803f4730` + scheduler-frame release                                                                                                    |
+| `FUN_1803ef3c0` | `+0x3EF3C0` | scheduler enqueue (sets up the frame at `ctx + 0x30`)                                                                                                 |
+| `FUN_1803f3170` | `+0x3F3170` | scheduler register (after `FUN_1803ef3c0`)                                                                                                            |
+| `FUN_180170830` | `+0x170830` | state-bit setter (encoded address)                                                                                                                    |
+| `FUN_1801707c0` | `+0x1707C0` | state-bit clearer (encoded address)                                                                                                                   |
+| `FUN_18017c270` | `+0x17C270` | brush-bit operation (`brushState`, `bitIdx`, `op`)                                                                                                    |
+| `FUN_18048c720` | `+0x48C720` | "transition to stage N" entry point                                                                                                                   |
+| `FUN_18048d140` | `+0x48D140` | stage-id -> stage record lookup                                                                                                                       |
+| `FUN_18048c8c0` | `+0x48C8C0` | install descriptor hook at `+0x38`                                                                                                                    |
+| `FUN_18048c8e0` | `+0x48C8E0` | install descriptor hook at `+0x40`                                                                                                                    |
+| `FUN_18048c8f0` | `+0x48C8F0` | install descriptor hook at `+0x48`                                                                                                                    |
+| `FUN_1804c4940` | `+0x4C4940` | CoN's stage init function (installs the three lifecycle hooks)                                                                                        |
+| `DAT_1807aa1b0` | `+0x7AA1B0` | master stage record table (16 bytes/entry)                                                                                                            |
+| `DAT_180b65ed0` | `+0xB65ED0` | active stage descriptor                                                                                                                               |
+
+Dispatch gates within `+0x39C` (mask convention: BitField bit N = `0x80000000 >> N`):
+
+| Bit | Mask         | Meaning                                                                                  |
+| --- | ------------ | ---------------------------------------------------------------------------------------- |
+| 9   | `0x00400000` | latch: `FUN_1804c1b10` already dispatched (set by `FUN_180170830(0x20009)`)              |
+| 17  | `0x00004000` | atomic-cleared near top of TICK by `FUN_180170830(0x20011)`; meaning unconfirmed         |
+| 21  | `0x00000400` | latch: `FUN_1804c31c0` already dispatched                                                |
+| 22  | `0x00000200` | also gates the entrance dispatch as a "do not re-fire" check                             |
+| 24  | `0x00000080` | "kami sequence done" — gates inner TICK input check                                      |
+| 25  | `0x00000040` | "kami appearing" — gates `FUN_1804c2ac0` dispatch                                        |
+| 26  | `0x00000020` | latch for bit-25 dispatch                                                                |
+| 27  | `0x00000010` | "rock slashed" — gates `FUN_1804c28d0` dispatch                                          |
+| 28  | `0x00000008` | latch for bit-27 dispatch                                                                |
+| 29  | `0x00000004` | "tutorial done" — gates `FUN_1804c2560` dispatch (no latch; see Pattern 1 variant above) |
+
+The bit-22 (`0x00000200`) entry is reused: the same bit acts as a gate-clear check before the entrance dispatch and as the latch for `FUN_1804c1f50` later in the TICK. Same address and bit, two different roles depending on which TICK section is reading it.
+
+Other state words touched by CoN's TICK chain:
+
+| Address  | Bit / mask           | Meaning                                                                      |
+| -------- | -------------------- | ---------------------------------------------------------------------------- |
+| `+0x35C` | bit 5 / `0x04000000` | cleared by `FUN_1801707c0(5)` in the entrance dispatch (purpose unconfirmed) |
+
+Dispatch gates within `+0x3A0`:
+
+| BitField bit | Mask         | Meaning                                      |
+| ------------ | ------------ | -------------------------------------------- |
+| 41 (low=41)  | `0x00400000` | "rejuv pending" — gates `FUN_1804c31c0`      |
+| 42 (low=42)  | `0x00200000` | "constellation done" — gates `FUN_1804c1f50` |
+
+## Stage architecture (one level above TICK)
+
+The CoN TICK has zero static call sites in main.dll. Its only xref is its `.pdata` exception-unwind entry. Despite that, scripts and TICKs in this engine are *not* loaded from external files: there is no separate script bytecode language. Scripts are compiled C++ callbacks baked into main.dll, scheduled by ID via `FUN_1803f35f0(ctx, script_id, ...)` and similar. So the TICK gets installed at runtime through some indirection that we haven't fully traced statically (likely a stage-id -> function-pointer table populated during stage init), but the answer lives somewhere inside main.dll, not in an on-disk script file. The on-disk room files (`data_pc/stN/rXXX.bin`) carry SCA trigger volumes, MSD strings, and per-room asset data, not callback pointers. That said, the *parallel* machinery (the stage descriptor object the TICK eventually drives) is fully visible in the binary.
+
+### Master stage record table
+
+`DAT_1807aa1b0` (`main.dll + 0x7AA1B0`) is a flat array of 16-byte records, indexed by stage id:
+
+```c
+struct StageRecord {
+    uint16_t script_id;     // e.g. 0x111e for Cave of Nagi
+    uint16_t pad;
+    uint32_t flags_or_param;
+    void*    stage_init_fn; // installs the descriptor's lifecycle hooks
+};
+```
+
+The lookup is `FUN_18048d140(descriptor, stage_id)`, and the higher-level "transition to stage N" entry point is `FUN_18048c720(descriptor, stage_id)`. Cave of Nagi sits at index 5 (`script_id=0x111e`, `stage_init_fn=FUN_1804c4940`).
+
+### Active stage descriptor
+
+`DAT_180b65ed0` is the global stage descriptor with three function-pointer slots installed by the per-stage init function:
+
+| Offset  | Setter          | Meaning                                     |
+| ------- | --------------- | ------------------------------------------- |
+| `+0x38` | `FUN_18048c8c0` | small per-stage hook (lifecycle / pre-tick) |
+| `+0x40` | `FUN_18048c8e0` | small per-stage hook                        |
+| `+0x48` | `FUN_18048c8f0` | small per-stage hook                        |
+
+CoN's `FUN_1804c4940` installs `LAB_1804c48d0` / `DAT_1804c4910` / `LAB_1804c4920` into these slots. These callbacks are tiny (≤30 bytes each) and are *not* the per-frame TICK; they are descriptor-lifecycle hooks. The TICK at `FUN_1804c4300` is dispatched separately, through some in-binary indirection we haven't fully resolved (the function has no static xrefs other than `.pdata`).
+
+There are around 318 references to `DAT_180b65ed0` across the binary, so this descriptor is the central object the rest of the per-stage machinery is built around. Calls to `FUN_18048c720(&DAT_180b65ed0, N)` with small N (we see `0x2a`, `0x55`, `0x94` in the wild) are intra-stage transitions to sub-state IDs.
+
+### What this means for bypass work
+
+The TICK and the callbacks it dispatches are all compiled into main.dll, so MinHook-ing them is the natural intervention point. There is no script-file format to patch separately; "scripts" in this engine are compiled C++ callbacks dispatched by ID, with the ID acting as an index into an in-binary table. The bits driving those dispatches are flipped by SCA trigger volumes from the room file *and* by other in-binary callbacks; the room file influences the chain by deciding *when* the player crosses a trigger zone, but the resulting handler is always baked-in code.
+
+For future bypass work, that means: hook the first link in the in-binary callback chain (as `confix.cpp` does), or, if the goal is per-room rather than per-event control, you could patch the SCA section of the room file to suppress the trigger zone that flips the gating bit in the first place. Both routes stay inside known, statically-analyzable territory; neither requires reverse-engineering an external script format because there isn't one. This section is here so the next person doesn't waste time looking for static call sites to the TICK that aren't there.

--- a/docs/event-triggers.md
+++ b/docs/event-triggers.md
@@ -1,0 +1,98 @@
+# Event Triggers
+
+Most "scripted" things that happen in a room (an enemy ambush spawning, a cutscene firing, Issun dialogue) are driven by trigger zones declared in the room's data file. The engine watches the player's position each tick, and when the player enters a zone, dispatches to a compiled C++ handler in `main.dll` keyed off the zone's parameters. There is no embedded script language; the zones are static records and the handlers are baked in.
+
+This doc covers the static on-disk format. For the runtime side — how the per-stage TICK reads state bits, dispatches handlers via the scheduler, and what we figured out while bypassing Cave of Nagi's forced-tutorial softlock — see [event-triggers-runtime.md](event-triggers-runtime.md).
+
+## Where the data lives
+
+Per-room data sits under `data_pc/stN/rXXX.bin`, where the stage subdirectory `stN` groups rooms by chapter and `rXXX` is the room ID in hex (e.g. Cave of Nagi is `0x101`, so its file is `data_pc/st1/r101.bin`). Companion files alongside each `.bin` carry localized strings and the heavier per-room asset blob (`r101.dat`, ~MBs of model and texture data). The `.bin` is the lightweight scene description; trigger zones live there.
+
+All of these files are Blowfish-encrypted (key `YaKiNiKuM2rrVrPJpGMkfe3EK4RbpbHw`, ECB, 8-byte blocks). After decryption the room file is a section-tagged container:
+
+```
++0x00  uint32        section count N
++0x04  uint32[N+1]   section start offsets (last is end-of-data sentinel)
++0x40  char[4][N]    4-byte type tags ("ACT\0", "SCA\0", ...)
++0x80  ...           section data
+```
+
+Trigger zones live in the section tagged `SCA`. Other tags in the same file carry the room's actor instances (`ACT`), dialogue strings (`MSD`), item placements (`ITS`), and so on. This doc covers SCA only.
+
+## SCA section header
+
+```
++0x00  char[4]   magic "SCA\0"
++0x04  uint8     flag_a (often 0)
++0x05  uint8     flag_b (often 1)
++0x06  uint16    entry count
++0x08  uint8[16] reserved/zero
++0x18  ...       entries (176 bytes each)
+```
+
+The two flag bytes don't have known meanings; they appear constant across rooms.
+
+## Entry layout
+
+Each SCA entry is 176 bytes (`0xB0`). Field positions are confirmed; the field *semantics* are inferred from observed values and not all of them are pinned down.
+
+```
++0x00  uint8     type
++0x01  uint8     subtype
++0x02  uint16    ?
++0x04  float     f1 (unknown; possibly a vertical bound or rotation)
++0x08  float     f2 (unknown)
++0x0C  uint32    zero/reserved
++0x10  float[8]  4 (x, z) ground-plane corners of the trigger quad
++0x30  uint8[8]  event params (handler dispatch info; see below)
++0x38  uint8[120] padding/reserved
+```
+
+The eight floats at `+0x10` decode cleanly as four `(x, z)` pairs that trace a quadrilateral on the ground plane. Y is the up-axis in Okami and isn't part of the quad; vertical extent is presumably supplied by `f1` / `f2` or unbounded. Real-world quads are usually convex but rarely axis-aligned, so don't reduce them to AABBs unless you only need a rough position.
+
+## Event params
+
+The 8-byte block at `+0x30` is the handler dispatch info. The pattern observed across an entire room's entries:
+
+```
+[ 0] 03 00 00 00 00 08 00 02
+[ 1] 03 00 01 00 00 08 00 02
+[ 2] 03 00 02 00 00 08 00 02
+...
+[ N] 03 NN NN 00 00 08 00 02
+```
+
+Best-guess decode:
+
+| Bytes   | Meaning                                                      |
+| ------- | ------------------------------------------------------------ |
+| `+0x00` | Handler type (constant per room, often `0x03`)               |
+| `+0x01` | Subtype (most entries 0; some entries differ, see below)     |
+| `+0x02` | uint16 trigger ID; sequential and matches the entry index    |
+| `+0x04` | uint8 (often 0)                                              |
+| `+0x05` | uint8 group code (often `0x08`)                              |
+| `+0x06` | uint16 terminal flag (commonly `0x02`; differs for outliers) |
+
+The trigger ID matching the entry's array position is the most useful invariant: if a handler reads `volume[N]` and dispatches by ID, the index maps directly to whichever scene that zone fires.
+
+## Reading a dump
+
+A few heuristics make a SCA dump easier to interpret without ground-truthing every entry by walking around the room.
+
+**Outlier params.** The subtype byte and the terminal-flag byte differ for a handful of entries per room. In one observed room the last entry had `subtype=1` and terminal flag `0x01` while every preceding entry had `subtype=0` and `0x02`. Outliers like this correlate with structurally different events (a "completion exit" rather than a "fire scene", for example). When skimming, those byte differences are the first place to look for entries doing something distinct from their neighbors.
+
+**Geographic clustering.** Trigger entries within a room tend to cluster geographically because the level designers placed them in the same region of the map. Sort entries by their average `(x, z)` and look for clusters separated by long jumps. Each cluster usually corresponds to a logical sub-area: an outdoor approach versus an indoor chamber, an enemy ambush lane versus a cutscene chamber, the spawn lane the player walks through on the way back out versus the original-direction triggers.
+
+**Overlapping pairs.** Two entries with overlapping AABBs are usually paired (a small "you crossed it" trigger inside a larger "you're still in the area" maintainer is a common shape). When suppressing one, check whether its sibling needs to go too.
+
+## Confidence and gaps
+
+Confirmed by inspection:
+
+- Container encryption (Blowfish + section table) and section type tags.
+- SCA entry stride (176 bytes) and the sequential trigger ID in the params block.
+
+Inferred but not confirmed:
+
+- Field semantics of the entry header (`f1`, `f2`, type/subtype byte ordering).
+- The exact dispatch function in `main.dll` that consumes SCA entries; we know it must exist but haven't located it.

--- a/src/okami-apclient/eventfix/cave_of_nagi.cpp
+++ b/src/okami-apclient/eventfix/cave_of_nagi.cpp
@@ -1,0 +1,50 @@
+#include "cave_of_nagi.hpp"
+
+#include <okami/brushes.hpp>
+#include <wolf_framework.hpp>
+
+#include "common.hpp"
+
+namespace eventfix::cave_of_nagi
+{
+
+namespace
+{
+
+// FUN_1804c1b10: entrance cutscene + portcullis-fall + script 0x1003.
+// Pure suppression -- the camera-lower and portcullis animation are
+// purely cosmetic; nothing else in CoN's chain depends on this firing.
+void __fastcall stubEntrance()
+{
+    eventfix::clearCutsceneModeBits();
+    wolf::logInfo("[eventfix] CoN entrance cutscene suppressed");
+}
+
+// FUN_1804c31c0: statue rejuv -> constellation puzzle -> kami dialog
+// chain. Granting the brush bit fires BrushMan's watcher (which sends
+// the AP check), and skipping the rest prevents +0x3A0 bit 10 (the
+// FUN_1804c1f50 dispatch gate) from being set, so the kami dialog +
+// forced rock-slash tutorial chain never fires.
+//
+// The natural FUN_1804c1f50 path also calls the same brush-bit-set; we
+// bypass that path entirely, so this is the only grant that fires.
+void __fastcall stubStatueRejuv()
+{
+    eventfix::clearCutsceneModeBits();
+    eventfix::grantBrush(okami::BrushOverlay::power_slash);
+    wolf::logInfo("[eventfix] CoN statue/kami suppressed; granted Power Slash");
+}
+
+constexpr EventBypass kBypasses[] = {
+    {"CoN entrance cutscene", 0x4C1B10, stubEntrance},
+    {"CoN statue rejuv chain", 0x4C31C0, stubStatueRejuv},
+};
+
+} // namespace
+
+std::span<const EventBypass> getBypasses()
+{
+    return kBypasses;
+}
+
+} // namespace eventfix::cave_of_nagi

--- a/src/okami-apclient/eventfix/cave_of_nagi.hpp
+++ b/src/okami-apclient/eventfix/cave_of_nagi.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <span>
+
+#include "registry.hpp"
+
+namespace eventfix::cave_of_nagi
+{
+
+// Bypass records for Cave of Nagi's forced-tutorial softlock. See
+// docs/event-triggers-runtime.md for the runtime model and chain.
+std::span<const EventBypass> getBypasses();
+
+} // namespace eventfix::cave_of_nagi

--- a/src/okami-apclient/eventfix/common.cpp
+++ b/src/okami-apclient/eventfix/common.cpp
@@ -1,0 +1,72 @@
+#include "common.hpp"
+
+#include <wolf_framework.hpp>
+
+namespace eventfix
+{
+
+namespace
+{
+
+// Module-relative offsets (image base 0x180000000 in Ghidra).
+constexpr uintptr_t kOff_AreaLoadFlags = 0xB6B2A0;
+constexpr uintptr_t kOff_GlobalStateWord0 = 0xB6B2AC;
+constexpr uint32_t kCutsceneModeBitsAreaFlags = 0x02802000;
+constexpr uint32_t kCutsceneModeBitsW0 = 0x40000040;
+
+constexpr uintptr_t kOff_BrushBitOp = 0x17C270;    // FUN_18017c270
+constexpr uintptr_t kOff_BrushState = 0x8909C0;    // DAT_1808909c0
+constexpr uintptr_t kOff_StateBitSet = 0x170830;   // FUN_180170830
+constexpr uintptr_t kOff_StateBitClear = 0x1707C0; // FUN_1801707c0
+
+using BrushBitOpFn = void(__fastcall *)(void *brushState, uint32_t bitIdx, int32_t op);
+using StateBitFn = void(__fastcall *)(uint32_t encoded);
+
+uintptr_t s_mainBase = 0;
+
+} // namespace
+
+bool initializeCommon()
+{
+    if (s_mainBase != 0)
+        return true;
+    s_mainBase = wolf::getModuleBase("main.dll");
+    return s_mainBase != 0;
+}
+
+void clearCutsceneModeBits()
+{
+    if (s_mainBase == 0)
+        return;
+    auto *areaFlags = reinterpret_cast<volatile uint32_t *>(s_mainBase + kOff_AreaLoadFlags);
+    *areaFlags &= ~kCutsceneModeBitsAreaFlags;
+    auto *gameStateW0 = reinterpret_cast<volatile uint32_t *>(s_mainBase + kOff_GlobalStateWord0);
+    *gameStateW0 &= ~kCutsceneModeBitsW0;
+}
+
+void grantBrush(okami::BrushOverlay brush)
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<BrushBitOpFn>(s_mainBase + kOff_BrushBitOp);
+    auto *brushState = reinterpret_cast<void *>(s_mainBase + kOff_BrushState);
+    fn(brushState, static_cast<uint32_t>(brush), 0);
+}
+
+void setStateBit(uint32_t encoded)
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<StateBitFn>(s_mainBase + kOff_StateBitSet);
+    fn(encoded);
+}
+
+void clearStateBit(uint32_t encoded)
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<StateBitFn>(s_mainBase + kOff_StateBitClear);
+    fn(encoded);
+}
+
+} // namespace eventfix

--- a/src/okami-apclient/eventfix/common.hpp
+++ b/src/okami-apclient/eventfix/common.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+#include <okami/brushes.hpp>
+
+namespace eventfix
+{
+
+// Clears the cutscene-mode bits set by the dispatcher's pre-call to
+// FUN_1803f4900. Mirrors the bits that function sets, NOT FUN_1803f4730
+// (the natural exit) which clears slightly different masks.
+//
+//   AreaLoadFlags (main.dll+0xB6B2A0) &= ~0x02802000
+//   GGS[0]        (main.dll+0xB6B2AC) &= ~0x40000040
+//
+// Call from a bypass stub to keep the camera in follow-Ammy mode and
+// release the input/scene lock the dispatcher imposed before scheduling
+// the suppressed callback.
+void clearCutsceneModeBits();
+
+// Sets the bit corresponding to `brush` in both the "usable"
+// (brushState+0x70) and "obtained" (brushState+0x78) bitfields. Wraps
+// FUN_18017c270 with op=0. BrushMan's watcher detects the transition
+// and fires the AP check for that brush.
+//
+// Note: the brush bitfields use little-endian-within-64-bit-word
+// encoding (1ULL << bit), the OPPOSITE of okami::BitField<N> and the
+// state-bit-setter convention. See setStateBit() for the BE side.
+void grantBrush(okami::BrushOverlay brush);
+
+// Set/clear a bit in the world-state struct via FUN_180170830 /
+// FUN_1801707c0 with the encoded address argument. Encoding:
+//
+//   addr = worldStateBase + (high16 * 0x20) + 0x35C + (low16/32) * 4
+//   mask = 0x80000000 >> (low16 % 32)        // BIG-endian within word
+//
+// Convention is the opposite of grantBrush(). Use these for poking the
+// engine's state-bit struct (gates, latches, etc.).
+void setStateBit(uint32_t encoded);
+void clearStateBit(uint32_t encoded);
+
+// Initialize shared state. Called by eventfix::initialize() before any
+// bypass is installed; binds the main.dll base address used by the
+// helpers above. Returns false if main.dll isn't loaded.
+bool initializeCommon();
+
+} // namespace eventfix

--- a/src/okami-apclient/eventfix/eventfix.cpp
+++ b/src/okami-apclient/eventfix/eventfix.cpp
@@ -1,0 +1,53 @@
+#include "eventfix.hpp"
+
+#include <span>
+
+#include <wolf_framework.hpp>
+
+#include "cave_of_nagi.hpp"
+#include "common.hpp"
+#include "registry.hpp"
+
+namespace eventfix
+{
+
+namespace
+{
+
+bool installBypass(const EventBypass &bypass)
+{
+    void *trampoline = nullptr;
+    if (!wolf::hookFunction("main.dll", bypass.funcOffset, reinterpret_cast<void *>(bypass.stub), &trampoline))
+    {
+        wolf::logError("[eventfix] failed to hook %s at +0x%llx", bypass.name, static_cast<unsigned long long>(bypass.funcOffset));
+        return false;
+    }
+    return true;
+}
+
+void installAll(std::span<const EventBypass> bypasses, int &installed)
+{
+    for (const auto &bypass : bypasses)
+    {
+        if (installBypass(bypass))
+            ++installed;
+    }
+}
+
+} // namespace
+
+void initialize()
+{
+    if (!initializeCommon())
+    {
+        wolf::logError("[eventfix] main.dll base not found; bypasses not installed");
+        return;
+    }
+
+    int installed = 0;
+    installAll(cave_of_nagi::getBypasses(), installed);
+
+    wolf::logInfo("[eventfix] installed %d bypass hooks", installed);
+}
+
+} // namespace eventfix

--- a/src/okami-apclient/eventfix/eventfix.hpp
+++ b/src/okami-apclient/eventfix/eventfix.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace eventfix
+{
+
+// Install all registered event bypasses. Call once during late game
+// init, after wolf is fully bound. Walks each per-map module's bypass
+// list and MinHooks the first-link callback with its replacement stub.
+//
+// See docs/event-triggers-runtime.md for the runtime model and the
+// "first-link" rule.
+void initialize();
+
+} // namespace eventfix

--- a/src/okami-apclient/eventfix/registry.hpp
+++ b/src/okami-apclient/eventfix/registry.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace eventfix
+{
+
+// A bypass record: replace the function at `funcOffset` (module-relative
+// to main.dll) with `stub`, a __fastcall void() replacement that does
+// NOT call the original. The stub typically clears cutscene-mode bits
+// via clearCutsceneModeBits() and runs whichever side-effect the
+// dispatch chain still requires (e.g. grantBrush()).
+//
+// Map gating and AP-conditional behavior, if needed, are the stub's
+// responsibility -- there's no shared predicate. Keep stubs cheap; they
+// run on the game's main thread.
+struct EventBypass
+{
+    const char *name;
+    uintptr_t funcOffset;
+    void (*stub)();
+};
+
+} // namespace eventfix

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -7,6 +7,7 @@
 #include "archipelagosocket.h"
 #include "checkman.h"
 #include "console_commands.h"
+#include "eventfix/eventfix.hpp"
 #include "gamestate_accessors.hpp"
 #include "itempatch.hpp"
 #include "rewardman.h"
@@ -87,6 +88,8 @@ class APClientMod
         // Install hooks before patchItemParams so they intercept game events.
         itempatch::initialize();
         itempatch::patchItemParams();
+
+        eventfix::initialize();
 
         g_saveMan = std::make_unique<SaveMan>(ArchipelagoSocket::instance());
         g_saveMan->initialize();

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -13,6 +13,9 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/data/msd.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data/resourcepkg.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data/shopdata.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/cave_of_nagi.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/common.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/eventfix.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gamestate_accessors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/itempatch.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/okami-apclient.cpp


### PR DESCRIPTION
## Description
Replaces the first callback in the affected dispatch chain with a stub that clears the dispatcher's pre-set cutscene-mode bits and runs whichever side-effect downstream code still requires. For CoN that means hooking `FUN_1804c1b10` (entrance) and `FUN_1804c31c0` (statue rejuv); the latter grants the Power Slash brush bit directly via `FUN_18017c270`, which fires `BrushMan`'s watcher for the AP check. Skipping the rest of the chain prevents the kami dialog and forced tutorial from ever being scheduled.

## Changes
- Adds an `eventfix` module that bypasses Cave of Nagi's forced rock-slash tutorial.
- Documents the room-event-trigger system: the static SCA format on disk, and the runtime per-stage TICK dispatch model.

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos
<!-- If applicable, show the changes in action -->

---

<!-- Thanks for contributing! -->
