### PR TITLE
Suppress brush checks during loading screens (#149)

### DIFF
--- a/src/okami-apclient/checkman.cpp
+++ b/src/okami-apclient/checkman.cpp
@@ -7,6 +7,7 @@
 #include "checks/containers.hpp"
 #include "checks/gamestate_monitors.hpp"
 #include "checks/shops.hpp"
+#include "gamestate_accessors.hpp"
 #include "isocket.h"
 
 CheckMan::CheckMan(ISocket &socket) : socket_(socket)
@@ -228,6 +229,19 @@ void CheckMan::sendCheck(int64_t checkId)
     if (!sendingEnabled_ || !socket_.isConnected())
     {
         wolf::logDebug("[CheckMan] Skipped check %" PRId64 " (sending=%d, connected=%d)", checkId, sendingEnabled_ ? 1 : 0, socket_.isConnected() ? 1 : 0);
+        return;
+    }
+
+    // Defense in depth: drop any check that fires mid-load. Today the
+    // other check sources (containers, shops, gamestate monitors) only
+    // fire on player input the engine doesn't process during a loading
+    // screen, so this is a no-op for them; it catches any future source
+    // that might fire from a map-init code path. BrushMan has its own
+    // earlier loading-phase gate because it also needs to block the
+    // bit-set, not just drop the queue. See issue #149.
+    if (apgame::isInLoadingPhase())
+    {
+        wolf::logDebug("[CheckMan] Skipped check %" PRId64 " (in loading phase)", checkId);
         return;
     }
 

--- a/src/okami-apclient/checks/brushes.cpp
+++ b/src/okami-apclient/checks/brushes.cpp
@@ -75,6 +75,18 @@ bool dispatchBrushEdit(int bitIndex, int operation, BrushMan &handler)
     if (!g_active.load(std::memory_order_acquire))
         return false;
 
+    // Block any brush set that fires during a map-load phase. The engine
+    // has safety-net code paths (e.g. CoN's FUN_1804c3c90) that set
+    // brush bits on map entry "just in case"; in AP mode those bits are
+    // randomized items, so we both suppress the AP check (the player
+    // didn't earn the location) AND block the set (don't let vanilla
+    // grant the brush). Issue #149.
+    if (apgame::isInLoadingPhase())
+    {
+        wolf::logDebug("[BrushMan] suppressed bit=%d (loading phase)", bitIndex);
+        return true;
+    }
+
     const int64_t checkId = getBrushCheckId(bitIndex);
 
     // Only intercept bits whose location ID is in the APWorld. Bits the

--- a/src/okami-apclient/eventfix/registry.hpp
+++ b/src/okami-apclient/eventfix/registry.hpp
@@ -9,11 +9,7 @@ namespace eventfix
 // to main.dll) with `stub`, a __fastcall void() replacement that does
 // NOT call the original. The stub typically clears cutscene-mode bits
 // via clearCutsceneModeBits() and runs whichever side-effect the
-// dispatch chain still requires (e.g. grantBrush()).
-//
-// Map gating and AP-conditional behavior, if needed, are the stub's
-// responsibility -- there's no shared predicate. Keep stubs cheap; they
-// run on the game's main thread.
+// dispatch chain still requires (e.g. grantBrush())
 struct EventBypass
 {
     const char *name;

--- a/src/okami-apclient/gamestate_accessors.cpp
+++ b/src/okami-apclient/gamestate_accessors.cpp
@@ -13,6 +13,7 @@ BitFieldAccessor<64> obtainedBrushesSource;
 BitFieldAccessor<32> keyItemsAcquired;
 BitFieldAccessor<32> goldDustsAcquired;
 BitFieldAccessor<32> brushUpgrades;
+BitFieldAccessor<86> globalGameState;
 Accessor<okami::CollectionData> collectionData;
 Accessor<okami::WorldStateData> worldStateData;
 Accessor<okami::TrackerData> trackerData;
@@ -50,11 +51,21 @@ void initialize()
     // Brush upgrades from TrackerData
     brushUpgrades = BitFieldAccessor<32>("main.dll", trackerDataAddr + offsetof(okami::TrackerData, brushUpgrades));
 
+    // Global game state flags (loading-screen bit 16, menu bit 17, etc.)
+    globalGameState = BitFieldAccessor<86>("main.dll", okami::main::globalGameStateFlags);
+
     // Item parameter table
     constexpr uintptr_t itemParamsAddr = 0x7AB220;
     itemParams = Accessor<std::array<okami::ItemParam, okami::ItemTypes::NUM_ITEM_TYPES>>("main.dll", itemParamsAddr);
 
     wolf::logInfo("[apgame] Game state accessors initialized");
+}
+
+bool isInLoadingPhase()
+{
+    if (!globalGameState.is_bound())
+        return false;
+    return globalGameState->IsSet(16);
 }
 
 } // namespace apgame

--- a/src/okami-apclient/gamestate_accessors.hpp
+++ b/src/okami-apclient/gamestate_accessors.hpp
@@ -28,6 +28,7 @@ extern BitFieldAccessor<64> obtainedBrushesSource;
 extern BitFieldAccessor<32> keyItemsAcquired;
 extern BitFieldAccessor<32> goldDustsAcquired;
 extern BitFieldAccessor<32> brushUpgrades;
+extern BitFieldAccessor<86> globalGameState;
 extern Accessor<okami::CollectionData> collectionData;
 extern Accessor<okami::WorldStateData> worldStateData;
 extern Accessor<okami::TrackerData> trackerData;
@@ -38,5 +39,10 @@ extern Accessor<std::array<okami::ItemParam, okami::ItemTypes::NUM_ITEM_TYPES>> 
 // Initialize all accessors
 // Must be called during mod startup before receiving any items
 void initialize();
+
+// True while the engine is mid-load (GGS bit 16, "Related to Loading
+// Screens?"). Used to suppress check-sending and brush-bit-set passes
+// that fire from map-init safety nets (see issue #149).
+bool isInLoadingPhase();
 
 } // namespace apgame

--- a/tests/test_brush_regression.cpp
+++ b/tests/test_brush_regression.cpp
@@ -598,6 +598,36 @@ TEST_CASE_METHOD(BrushManFixture, "BrushMan: bit with no APWorld location is ful
     tearDown();
 }
 
+TEST_CASE_METHOD(BrushManFixture, "BrushMan: suppressed during loading phase (GGS bit 16)", "[brush][regression][brushman][loading]")
+{
+    // Reproduces issue #149: on Cave of Nagi entry, FUN_1804c3c90 (a
+    // sizeable map-init function) calls the brush-bit-set with bit 22
+    // (Rejuvenation) as a vanilla safety net. The hook must not queue
+    // an AP check for this; in AP mode the brush is randomized and the
+    // player hasn't earned the location. The hook must ALSO block the
+    // set, or vanilla would grant the brush behind AP's back.
+    setUp();
+
+    // Simulate the loading screen: GGS bit 16 ("Related to Loading
+    // Screens?") set. This is what flips 1->0 when WOLF logs
+    // "Game Loaded and Gameplay Started (flag 16: Loading -> gameplay)".
+    apgame::globalGameState->Set(16);
+
+    bool blocked = wolf::mock::triggerBrushEdit(22, 0);
+    CHECK(blocked); // bit set blocked
+    brushMan_->tick();
+    CHECK(sentChecks_.empty()); // and no check queued
+
+    // Sanity: once the load completes, the next set queues normally.
+    apgame::globalGameState->Clear(16);
+    REQUIRE(wolf::mock::triggerBrushEdit(22, 0));
+    brushMan_->tick();
+    REQUIRE(sentChecks_.size() == 1);
+    CHECK(sentChecks_[0] == checks::getBrushCheckId(22));
+
+    tearDown();
+}
+
 TEST_CASE_METHOD(BrushManFixture, "BrushMan: out-of-range bitIndex falls through", "[brush][regression][brushman][gating]")
 {
     setUp();


### PR DESCRIPTION
Engine map-init code paths (e.g. CoN's FUN_1804c3c90) set brush bits on map entry as vanilla safety nets, which BrushMan was queueing as spurious AP location checks. Gate dispatchBrushEdit and CheckMan::sendCheck on GlobalGameState bit 16 (loading phase) so map-load brush sets are blocked and silently dropped.

## Related Issues
Fixes #149 