### PR TITLE
Bypass Kamiki water lily tutorial

### DIFF
--- a/docs/event-triggers-runtime.md
+++ b/docs/event-triggers-runtime.md
@@ -210,6 +210,20 @@ Dispatch gates within `+0x3A0`:
 | 41 (low=41)  | `0x00400000` | "rejuv pending" — gates `FUN_1804c31c0`      |
 | 42 (low=42)  | `0x00200000` | "constellation done" — gates `FUN_1804c1f50` |
 
+## Kamiki Village Water Lily chain (reference)
+
+Confirmed offsets and dispatch order for the Sakuya descent + Water Lily grant + forced lily-pad tutorial. Hooked the same way as CoN: replace `FUN_1804c64a0` with a stub that grants the brush and jumps the stage descriptor to sub-state `0xe`.
+
+| Function        | Offset      | Role                                                                                                                                                  |
+| --------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FUN_1804c64a0` | `+0x4C64A0` | first link (no static xrefs; TICK-dispatched). Steps stage descriptor 10 -> 11 -> 12 via `FUN_18048c720`, pokes worldStateBase `+0x3cc` bit 4 and `+0x3bc` bit `0x10`, schedules `FUN_1804c7d80`. |
+| `FUN_1804c7d80` | `+0x4C7D80` | Sakuya descent + camera/UI fade ramp. Sets `+0x35C` bits, transitions descriptor to `0xd`, schedules `FUN_1804ca430`.                                 |
+| `FUN_1804ca430` | `+0x4CA430` | Water Lily grant: `FUN_18017c270(brushState, 5)`. Plays grant animation; runs `FUN_1803f5170(.., FUN_1804ca860, ..)` to enter the tutorial loop; queues scripts `0x10f5`, `0x10f6`. |
+| `FUN_1804ca860` | `+0x4CA860` | lily-pad practice loop. Success path transitions stage descriptor to `0xe` via `FUN_18048c720` and calls `FUN_180170690(brushState)`.                 |
+| `FUN_18048c720` | `+0x48C720` | "transition to sub-state N" entry point (also documented in the CoN reference above)                                                                  |
+
+The bypass installed by `src/okami-apclient/eventfix/kamiki_village.cpp` replaces `FUN_1804c64a0` with a stub that calls `clearCutsceneModeBits()`, `grantBrush(BrushOverlay::water_lily)`, and `transitionStageSubState(0xe)`. The natural chain's per-map state writes (e.g. `KamikiVillage` worldStateBits 11 / 149 / 163) are set elsewhere (trigger volumes, post-bloom scripts); the bypass does not interact with them.
+
 ## Stage architecture (one level above TICK)
 
 The CoN TICK has zero static call sites in main.dll. Its only xref is its `.pdata` exception-unwind entry. Despite that, scripts and TICKs in this engine are *not* loaded from external files: there is no separate script bytecode language. Scripts are compiled C++ callbacks baked into main.dll, scheduled by ID via `FUN_1803f35f0(ctx, script_id, ...)` and similar. So the TICK gets installed at runtime through some indirection that we haven't fully traced statically (likely a stage-id -> function-pointer table populated during stage init), but the answer lives somewhere inside main.dll, not in an on-disk script file. The on-disk room files (`data_pc/stN/rXXX.bin`) carry SCA trigger volumes, MSD strings, and per-room asset data, not callback pointers. That said, the *parallel* machinery (the stage descriptor object the TICK eventually drives) is fully visible in the binary.

--- a/src/okami-apclient/eventfix/common.cpp
+++ b/src/okami-apclient/eventfix/common.cpp
@@ -20,10 +20,15 @@ constexpr uintptr_t kOff_StateBitSet = 0x170830;             // FUN_180170830
 constexpr uintptr_t kOff_StateBitClear = 0x1707C0;           // FUN_1801707c0
 constexpr uintptr_t kOff_StageSubStateTransition = 0x48C720; // FUN_18048c720
 constexpr uintptr_t kOff_StageDescriptor = 0xB65ED0;         // DAT_180b65ed0
+constexpr uintptr_t kOff_BrushStateRelease = 0x170690;       // FUN_180170690
+constexpr uintptr_t kOff_SchedulerExit = 0x3F48D0;           // FUN_1803f48d0
+constexpr uintptr_t kOff_StageMainCtx = 0x7A8CB0;            // PTR_DAT_1807a8cb0
 
 using BrushBitOpFn = void(__fastcall *)(void *brushState, uint32_t bitIdx, int32_t op);
 using StateBitFn = void(__fastcall *)(uint32_t encoded);
 using SubStateFn = void(__fastcall *)(void *descriptor, uint32_t subStateId);
+using BrushReleaseFn = void(__fastcall *)(void *brushState);
+using SchedulerExitFn = void(__fastcall *)(void *ctx, uint64_t flag);
 
 uintptr_t s_mainBase = 0;
 
@@ -79,6 +84,24 @@ void transitionStageSubState(uint32_t subStateId)
     auto fn = reinterpret_cast<SubStateFn>(s_mainBase + kOff_StageSubStateTransition);
     auto *descriptor = reinterpret_cast<void *>(s_mainBase + kOff_StageDescriptor);
     fn(descriptor, subStateId);
+}
+
+void releaseBrushState()
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<BrushReleaseFn>(s_mainBase + kOff_BrushStateRelease);
+    auto *brushState = reinterpret_cast<void *>(s_mainBase + kOff_BrushState);
+    fn(brushState);
+}
+
+void releaseSchedulerFrame()
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<SchedulerExitFn>(s_mainBase + kOff_SchedulerExit);
+    auto *ctx = reinterpret_cast<void *>(s_mainBase + kOff_StageMainCtx);
+    fn(ctx, 1);
 }
 
 } // namespace eventfix

--- a/src/okami-apclient/eventfix/common.cpp
+++ b/src/okami-apclient/eventfix/common.cpp
@@ -14,13 +14,16 @@ constexpr uintptr_t kOff_GlobalStateWord0 = 0xB6B2AC;
 constexpr uint32_t kCutsceneModeBitsAreaFlags = 0x02802000;
 constexpr uint32_t kCutsceneModeBitsW0 = 0x40000040;
 
-constexpr uintptr_t kOff_BrushBitOp = 0x17C270;    // FUN_18017c270
-constexpr uintptr_t kOff_BrushState = 0x8909C0;    // DAT_1808909c0
-constexpr uintptr_t kOff_StateBitSet = 0x170830;   // FUN_180170830
-constexpr uintptr_t kOff_StateBitClear = 0x1707C0; // FUN_1801707c0
+constexpr uintptr_t kOff_BrushBitOp = 0x17C270;              // FUN_18017c270
+constexpr uintptr_t kOff_BrushState = 0x8909C0;              // DAT_1808909c0
+constexpr uintptr_t kOff_StateBitSet = 0x170830;             // FUN_180170830
+constexpr uintptr_t kOff_StateBitClear = 0x1707C0;           // FUN_1801707c0
+constexpr uintptr_t kOff_StageSubStateTransition = 0x48C720; // FUN_18048c720
+constexpr uintptr_t kOff_StageDescriptor = 0xB65ED0;         // DAT_180b65ed0
 
 using BrushBitOpFn = void(__fastcall *)(void *brushState, uint32_t bitIdx, int32_t op);
 using StateBitFn = void(__fastcall *)(uint32_t encoded);
+using SubStateFn = void(__fastcall *)(void *descriptor, uint32_t subStateId);
 
 uintptr_t s_mainBase = 0;
 
@@ -67,6 +70,15 @@ void clearStateBit(uint32_t encoded)
         return;
     auto fn = reinterpret_cast<StateBitFn>(s_mainBase + kOff_StateBitClear);
     fn(encoded);
+}
+
+void transitionStageSubState(uint32_t subStateId)
+{
+    if (s_mainBase == 0)
+        return;
+    auto fn = reinterpret_cast<SubStateFn>(s_mainBase + kOff_StageSubStateTransition);
+    auto *descriptor = reinterpret_cast<void *>(s_mainBase + kOff_StageDescriptor);
+    fn(descriptor, subStateId);
 }
 
 } // namespace eventfix

--- a/src/okami-apclient/eventfix/common.cpp
+++ b/src/okami-apclient/eventfix/common.cpp
@@ -99,8 +99,16 @@ void releaseSchedulerFrame()
 {
     if (s_mainBase == 0)
         return;
+    // kOff_StageMainCtx is the address of a pointer (Ghidra PTR_DAT_*),
+    // not a struct in place. Natural callers pass the dereferenced
+    // pointer value as ctx; FUN_1803f48d0 then reads *(ctx+0x30) for
+    // the scheduler frame. Passing the raw address instead reads
+    // unrelated memory and crashes.
+    auto **ctxSlot = reinterpret_cast<void **>(s_mainBase + kOff_StageMainCtx);
+    auto *ctx = *ctxSlot;
+    if (ctx == nullptr)
+        return;
     auto fn = reinterpret_cast<SchedulerExitFn>(s_mainBase + kOff_SchedulerExit);
-    auto *ctx = reinterpret_cast<void *>(s_mainBase + kOff_StageMainCtx);
     fn(ctx, 1);
 }
 

--- a/src/okami-apclient/eventfix/common.cpp
+++ b/src/okami-apclient/eventfix/common.cpp
@@ -20,14 +20,12 @@ constexpr uintptr_t kOff_StateBitSet = 0x170830;             // FUN_180170830
 constexpr uintptr_t kOff_StateBitClear = 0x1707C0;           // FUN_1801707c0
 constexpr uintptr_t kOff_StageSubStateTransition = 0x48C720; // FUN_18048c720
 constexpr uintptr_t kOff_StageDescriptor = 0xB65ED0;         // DAT_180b65ed0
-constexpr uintptr_t kOff_BrushStateRelease = 0x170690;       // FUN_180170690
 constexpr uintptr_t kOff_SchedulerExit = 0x3F48D0;           // FUN_1803f48d0
 constexpr uintptr_t kOff_StageMainCtx = 0x7A8CB0;            // PTR_DAT_1807a8cb0
 
 using BrushBitOpFn = void(__fastcall *)(void *brushState, uint32_t bitIdx, int32_t op);
 using StateBitFn = void(__fastcall *)(uint32_t encoded);
 using SubStateFn = void(__fastcall *)(void *descriptor, uint32_t subStateId);
-using BrushReleaseFn = void(__fastcall *)(void *brushState);
 using SchedulerExitFn = void(__fastcall *)(void *ctx, uint64_t flag);
 
 uintptr_t s_mainBase = 0;
@@ -84,15 +82,6 @@ void transitionStageSubState(uint32_t subStateId)
     auto fn = reinterpret_cast<SubStateFn>(s_mainBase + kOff_StageSubStateTransition);
     auto *descriptor = reinterpret_cast<void *>(s_mainBase + kOff_StageDescriptor);
     fn(descriptor, subStateId);
-}
-
-void releaseBrushState()
-{
-    if (s_mainBase == 0)
-        return;
-    auto fn = reinterpret_cast<BrushReleaseFn>(s_mainBase + kOff_BrushStateRelease);
-    auto *brushState = reinterpret_cast<void *>(s_mainBase + kOff_BrushState);
-    fn(brushState);
 }
 
 void releaseSchedulerFrame()

--- a/src/okami-apclient/eventfix/common.hpp
+++ b/src/okami-apclient/eventfix/common.hpp
@@ -51,12 +51,6 @@ void clearStateBit(uint32_t encoded);
 // No-op if initializeCommon() has not bound the main.dll base.
 void transitionStageSubState(uint32_t subStateId);
 
-// Release the brush state lock via FUN_180170690(brushState). Used in
-// bypass cleanup where the brush state has been engaged (e.g. by a
-// cinematic that pulls up the celestial brush) and the natural release
-// path in the suppressed callback won't run.
-void releaseBrushState();
-
 // Run the natural cutscene-exit + scheduler-frame release via
 // FUN_1803f48d0(stageCtx, 1). This is what FUN_1804ca860's success
 // path (and other tutorial completion handlers) call at the tail. It

--- a/src/okami-apclient/eventfix/common.hpp
+++ b/src/okami-apclient/eventfix/common.hpp
@@ -40,6 +40,17 @@ void grantBrush(okami::BrushOverlay brush);
 void setStateBit(uint32_t encoded);
 void clearStateBit(uint32_t encoded);
 
+// Drive the active stage descriptor (DAT_180b65ed0) into sub-state
+// `subStateId` via FUN_18048c720(descriptor, subStateId). The stage
+// descriptor governs per-stage callback installation and lifecycle;
+// most natural tutorial chains end by transitioning to a specific
+// sub-state in their epilogue. Call this from a bypass stub to land
+// the descriptor in the same state the natural chain would have
+// reached, without running the chain.
+//
+// No-op if initializeCommon() has not bound the main.dll base.
+void transitionStageSubState(uint32_t subStateId);
+
 // Initialize shared state. Called by eventfix::initialize() before any
 // bypass is installed; binds the main.dll base address used by the
 // helpers above. Returns false if main.dll isn't loaded.

--- a/src/okami-apclient/eventfix/common.hpp
+++ b/src/okami-apclient/eventfix/common.hpp
@@ -51,6 +51,23 @@ void clearStateBit(uint32_t encoded);
 // No-op if initializeCommon() has not bound the main.dll base.
 void transitionStageSubState(uint32_t subStateId);
 
+// Release the brush state lock via FUN_180170690(brushState). Used in
+// bypass cleanup where the brush state has been engaged (e.g. by a
+// cinematic that pulls up the celestial brush) and the natural release
+// path in the suppressed callback won't run.
+void releaseBrushState();
+
+// Run the natural cutscene-exit + scheduler-frame release via
+// FUN_1803f48d0(stageCtx, 1). This is what FUN_1804ca860's success
+// path (and other tutorial completion handlers) call at the tail. It
+// internally invokes FUN_1803f4730 (a broader cutscene-mode clear than
+// clearCutsceneModeBits) plus FUN_1804561d0 to release the active
+// scheduler frame. Touches the active stage scheduler context at
+// PTR_DAT_1807a8cb0, so it must be called from a stub running on a
+// valid scheduler frame (any MinHook-installed bypass dispatched via
+// the natural TICK path qualifies).
+void releaseSchedulerFrame();
+
 // Initialize shared state. Called by eventfix::initialize() before any
 // bypass is installed; binds the main.dll base address used by the
 // helpers above. Returns false if main.dll isn't loaded.

--- a/src/okami-apclient/eventfix/eventfix.cpp
+++ b/src/okami-apclient/eventfix/eventfix.cpp
@@ -6,6 +6,7 @@
 
 #include "cave_of_nagi.hpp"
 #include "common.hpp"
+#include "kamiki_village.hpp"
 #include "registry.hpp"
 
 namespace eventfix
@@ -46,6 +47,7 @@ void initialize()
 
     int installed = 0;
     installAll(cave_of_nagi::getBypasses(), installed);
+    installAll(kamiki_village::getBypasses(), installed);
 
     wolf::logInfo("[eventfix] installed %d bypass hooks", installed);
 }

--- a/src/okami-apclient/eventfix/kamiki_village.cpp
+++ b/src/okami-apclient/eventfix/kamiki_village.cpp
@@ -32,9 +32,16 @@ namespace
 //
 //   * clear DAT_180b6b2a0 bit 0x80         (tutorial input-lock)
 //   * clear DAT_180b6b2a4 bits 0x20020004  (secondary cinematic flags)
-//   * call FUN_180170690(brushState)        (brush state release)
 //   * call FUN_1803f48d0(stageCtx, 1)       (full cutscene-exit and
 //                                            scheduler-frame release)
+//
+// We deliberately do NOT call FUN_180170690 ("restore brush state")
+// even though the natural success path ends with it. That function
+// memcpy's a backup region at brushState+0xC0..+0x108 over the live
+// brush bitfields at +0x70 and +0x80, and is paired with
+// FUN_1801706d0 (save) at the tutorial's start. Without a prior save
+// the backup is uninitialized, so calling the restore wipes every
+// brush the player owns.
 void __fastcall stubWaterLilyTutorial()
 {
     eventfix::clearCutsceneModeBits();
@@ -46,7 +53,6 @@ void __fastcall stubWaterLilyTutorial()
         *reinterpret_cast<volatile uint32_t *>(base + 0xB6B2A4) &= ~0x20020004u;
     }
 
-    eventfix::releaseBrushState();
     eventfix::grantBrush(okami::BrushOverlay::water_lily);
     eventfix::transitionStageSubState(0xe);
     eventfix::releaseSchedulerFrame();

--- a/src/okami-apclient/eventfix/kamiki_village.cpp
+++ b/src/okami-apclient/eventfix/kamiki_village.cpp
@@ -23,11 +23,34 @@ namespace
 // the stage descriptor to sub-state 0xe (the post-tutorial state
 // FUN_1804ca860's success path transitions to). Everything in between
 // is camera/animation/script and has no AP-side effect.
+//
+// In-game testing revealed the minimal stub (clearCutsceneModeBits +
+// grantBrush + transitionStageSubState) is insufficient: when the
+// player reaches the trigger, prior cinematic state leaves the camera
+// and input locked. The natural FUN_1804ca860 success path does more
+// cleanup; we mirror the subset of it that controls camera/input:
+//
+//   * clear DAT_180b6b2a0 bit 0x80         (tutorial input-lock)
+//   * clear DAT_180b6b2a4 bits 0x20020004  (secondary cinematic flags)
+//   * call FUN_180170690(brushState)        (brush state release)
+//   * call FUN_1803f48d0(stageCtx, 1)       (full cutscene-exit and
+//                                            scheduler-frame release)
 void __fastcall stubWaterLilyTutorial()
 {
     eventfix::clearCutsceneModeBits();
+
+    auto base = wolf::getModuleBase("main.dll");
+    if (base != 0)
+    {
+        *reinterpret_cast<volatile uint32_t *>(base + 0xB6B2A0) &= ~0x80u;
+        *reinterpret_cast<volatile uint32_t *>(base + 0xB6B2A4) &= ~0x20020004u;
+    }
+
+    eventfix::releaseBrushState();
     eventfix::grantBrush(okami::BrushOverlay::water_lily);
     eventfix::transitionStageSubState(0xe);
+    eventfix::releaseSchedulerFrame();
+
     wolf::logInfo("[eventfix] Kamiki Water Lily tutorial suppressed; granted Water Lily");
 }
 

--- a/src/okami-apclient/eventfix/kamiki_village.cpp
+++ b/src/okami-apclient/eventfix/kamiki_village.cpp
@@ -1,0 +1,45 @@
+#include "kamiki_village.hpp"
+
+#include <okami/brushes.hpp>
+#include <wolf_framework.hpp>
+
+#include "common.hpp"
+
+namespace eventfix::kamiki_village
+{
+
+namespace
+{
+
+// FUN_1804c64a0: first link in the Sakuya descent -> Water Lily grant
+// -> forced lily-pad tutorial chain. Calls FUN_18048c720(descriptor,
+// 10/11/12) to step the stage descriptor into the tutorial transient
+// states, then schedules FUN_1804c7d80 (Sakuya descent / camera fade)
+// which schedules FUN_1804ca430 (the actual Water Lily grant +
+// FUN_1804ca860 tutorial loop).
+//
+// The skip-the-first-link approach: replace this entry with a stub
+// that grants Water Lily so BrushMan fires the AP check, then jumps
+// the stage descriptor to sub-state 0xe (the post-tutorial state
+// FUN_1804ca860's success path transitions to). Everything in between
+// is camera/animation/script and has no AP-side effect.
+void __fastcall stubWaterLilyTutorial()
+{
+    eventfix::clearCutsceneModeBits();
+    eventfix::grantBrush(okami::BrushOverlay::water_lily);
+    eventfix::transitionStageSubState(0xe);
+    wolf::logInfo("[eventfix] Kamiki Water Lily tutorial suppressed; granted Water Lily");
+}
+
+constexpr EventBypass kBypasses[] = {
+    {"Kamiki Water Lily tutorial", 0x4C64A0, stubWaterLilyTutorial},
+};
+
+} // namespace
+
+std::span<const EventBypass> getBypasses()
+{
+    return kBypasses;
+}
+
+} // namespace eventfix::kamiki_village

--- a/src/okami-apclient/eventfix/kamiki_village.hpp
+++ b/src/okami-apclient/eventfix/kamiki_village.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <span>
+
+#include "registry.hpp"
+
+namespace eventfix::kamiki_village
+{
+
+std::span<const EventBypass> getBypasses();
+
+} // namespace eventfix::kamiki_village

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -16,6 +16,7 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/cave_of_nagi.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/common.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/eventfix.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/kamiki_village.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gamestate_accessors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/itempatch.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/okami-apclient.cpp


### PR DESCRIPTION
Bypass the forced Water Lily tutorial in Kamiki Village (healed). The bloom-fest minigame, Hasugami constellation, and Sakuya descent cinematic play normally; the input-locked lily-pad practice and its Issun preamble are skipped, and the player drops directly into Issun's post-tutorial dialog with full brush + camera control.