### PR TITLE
Sync Radomized containers between different versions of the same map

### DIFF
--- a/src/okami-apclient/checks/containers.cpp
+++ b/src/okami-apclient/checks/containers.cpp
@@ -6,6 +6,7 @@
 #include <okami/spawntable.h>
 
 #include <okami/itemtype.hpp>
+#include <okami/maptype.hpp>
 #include <wolf_framework.hpp>
 
 #include "../itempatch.hpp"
@@ -94,6 +95,40 @@ void ContainerMan::onSpawnTablePopulate(void *spawnTable)
     uintptr_t mainBase = reinterpret_cast<uintptr_t>(wolf::getModuleBase("main.dll"));
     auto *currentMapPtr = reinterpret_cast<uint16_t *>(mainBase + CURRENT_MAP_ID_OFFSET);
     currentLevelId_ = *currentMapPtr;
+    uint16_t replaceLevelId = currentLevelId_;
+
+    // For maps that have different versions, we replace their id to make containers form every version sync
+
+    // Using a switch instead of doing maths with map ids to ensure we don't set currentLevelId_ to an ivalid map.
+    switch (currentLevelId_)
+    {
+    case okami::MapID::ShinshuFieldCursed:
+        replaceLevelId = okami::MapID::ShinshuFieldHealed;
+        break;
+    case okami::MapID::AgataForestCursed:
+        replaceLevelId = okami::MapID::AgataForestHealed;
+        break;
+    case okami::MapID::TakaPassCursed:
+        replaceLevelId = okami::MapID::TakaPassHealed;
+        break;
+    case okami::MapID::RyoshimaCoastCursed:
+        replaceLevelId = okami::MapID::RyoshimaCoastHealed;
+        break;
+    case okami::MapID::KamuiCursed:
+        replaceLevelId = okami::MapID::KamuiHealed;
+        break;
+    case okami::MapID::KamikiVillagePostTei:
+        replaceLevelId = okami::MapID::KamikiVillage;
+        break;
+    default:
+        break;
+    }
+
+    if (replaceLevelId != currentLevelId_)
+    {
+        wolf::logDebug("[ContainerMan] Using id 0x%02X instead of 0x%02X for this map.", replaceLevelId, currentLevelId_);
+        currentLevelId_ = replaceLevelId;
+    }
 
     // Clear tracking from previous level
     trackedContainerIndices_.clear();


### PR DESCRIPTION
## Description
This PR changes the Level Id when loading some area to the one for the most used version of the map; This allows the containers to be properly randomized in both versions of the maps, and to maintain their state no matter which version of the map they've been opened in.

## Changes
- Add switch to change level id before resetting container manager for specific areas
- 
- 

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
Fixes #154 
