### PR TITLE
Feat: Add traps: inkwell drain, damage, astral pouch drain

### DIFF
--- a/src/okami-apclient/gamestate_accessors.cpp
+++ b/src/okami-apclient/gamestate_accessors.cpp
@@ -6,6 +6,7 @@ namespace apgame
 {
 
 // Define storage for accessors
+Accessor<okami::CharacterStats> characterStats;
 BitFieldAccessor<64> usableBrushTechniques;
 BitFieldAccessor<64> obtainedBrushTechniques;
 BitFieldAccessor<64> usableBrushesSource;
@@ -23,6 +24,9 @@ Accessor<std::array<okami::ItemParam, okami::ItemTypes::NUM_ITEM_TYPES>> itemPar
 
 void initialize()
 {
+    // CharacterStats is at 0xB4DF90
+    characterStats = Accessor<okami::CharacterStats>("main.dll", okami::main::characterStats);
+
     // CollectionData is at 0xB205D0
     constexpr uintptr_t collectionDataAddr = 0xB205D0;
     collectionData = Accessor<okami::CollectionData>("main.dll", collectionDataAddr);

--- a/src/okami-apclient/gamestate_accessors.hpp
+++ b/src/okami-apclient/gamestate_accessors.hpp
@@ -18,6 +18,7 @@ template <typename T> using Accessor = wolf::MemoryAccessor<T>;
 
 // Game state accessors
 // These are initialized at runtime with proper memory addresses
+extern Accessor<okami::CharacterStats> characterStats;
 extern BitFieldAccessor<64> usableBrushTechniques;
 extern BitFieldAccessor<64> obtainedBrushTechniques;
 // BrushData source: WorldStateData copies above are propagated from these bits,

--- a/src/okami-apclient/okami-apclient.cpp
+++ b/src/okami-apclient/okami-apclient.cpp
@@ -11,6 +11,7 @@
 #include "gamestate_accessors.hpp"
 #include "itempatch.hpp"
 #include "rewardman.h"
+#include "rewards/traps.hpp"
 #include "saveman.h"
 #include "ui/loginwindow.h"
 #include "ui/notificationwindow.h"

--- a/src/okami-apclient/rewardman.cpp
+++ b/src/okami-apclient/rewardman.cpp
@@ -7,6 +7,7 @@
 #include "rewards/brushes.hpp"
 #include "rewards/event_flags.hpp"
 #include "rewards/game_items.hpp"
+#include "rewards/traps.hpp"
 
 RewardMan::RewardMan(CheckSendingCallback onCheckSendingChange) : onCheckSendingChange_(std::move(onCheckSendingChange))
 {
@@ -95,6 +96,9 @@ std::expected<void, rewards::RewardError> RewardMan::grantReward(int64_t apItemI
         break;
     case rewards::RewardCategory::EventFlag:
         result = rewards::event_flags::grant(apItemId);
+        break;
+    case rewards::RewardCategory::Trap:
+        result = rewards::traps::grant(apItemId);
         break;
     case rewards::RewardCategory::Unknown:
         wolf::logDebug("[RewardMan] Skipping unrecognized AP item 0x%" PRIX64, apItemId);

--- a/src/okami-apclient/rewards/reward_types.hpp
+++ b/src/okami-apclient/rewards/reward_types.hpp
@@ -19,6 +19,8 @@ inline constexpr int64_t kProgressiveWeaponBase = 0x300;
 inline constexpr int64_t kProgressiveWeaponEnd = 0x302;
 inline constexpr int64_t kEventFlagBase = 0x303;
 inline constexpr int64_t kEventFlagEnd = 0x308;
+inline constexpr int64_t kTrapBase = 0x400;
+inline constexpr int64_t kTrapEnd = 0x4FF;
 
 /**
  * @brief Categories of rewards based on AP item ID ranges
@@ -28,6 +30,7 @@ enum class RewardCategory
     GameItem,  // 0x00-0xFF: direct game items, 0x300-0x302: progressive weapons
     Brush,     // 0x100-0x11E: brush techniques (some progressive)
     EventFlag, // 0x303-0x308: event flags to set
+    Trap,      // 0x400-0x4FF: trap effects
     Unknown    // Unrecognized AP item ID
 };
 
@@ -54,6 +57,10 @@ enum class RewardCategory
     if (apItemId >= kEventFlagBase && apItemId <= kEventFlagEnd)
     {
         return RewardCategory::EventFlag;
+    }
+    if (apItemId >= kTrapBase && apItemId <= kTrapEnd)
+    {
+        return RewardCategory::Trap;
     }
     return RewardCategory::Unknown;
 }

--- a/src/okami-apclient/rewards/traps.cpp
+++ b/src/okami-apclient/rewards/traps.cpp
@@ -14,7 +14,9 @@ namespace rewards::traps
 namespace
 {
 
-// 50% of max HP, floored at 1 so it never kills.
+/**
+ * @brief Deal 50% of max HP, floored at 1 so it never kills
+ */
 void applyDamageTrap()
 {
     auto *stats = apgame::characterStats.get_ptr();
@@ -29,6 +31,9 @@ void applyDamageTrap()
     notificationwindow::queue("[Trap] Evil Charm: lost half your health");
 }
 
+/**
+ * @brief Drain all current ink
+ */
 void applyInkLossTrap()
 {
     apgame::collectionData->currentInk = 0;
@@ -37,6 +42,9 @@ void applyInkLossTrap()
     notificationwindow::queue("[Trap] Dry Inkwell: ink drained");
 }
 
+/**
+ * @brief Drain the Astral Pouch (food) reserve
+ */
 void applyFoodLossTrap()
 {
     apgame::characterStats->currentFood = 0;

--- a/src/okami-apclient/rewards/traps.cpp
+++ b/src/okami-apclient/rewards/traps.cpp
@@ -1,0 +1,70 @@
+#include "traps.hpp"
+
+#include <cinttypes>
+#include <cstdint>
+
+#include <wolf_framework.hpp>
+
+#include "../gamestate_accessors.hpp"
+#include "../ui/notificationwindow.h"
+
+namespace rewards::traps
+{
+
+namespace
+{
+
+// 50% of max HP, floored at 1 so it never kills.
+void applyDamageTrap()
+{
+    auto *stats = apgame::characterStats.get_ptr();
+
+    uint16_t damage = stats->maxHealth / 2;
+    if (damage < 1)
+        damage = 1;
+
+    stats->currentHealth = (stats->currentHealth > damage) ? static_cast<uint16_t>(stats->currentHealth - damage) : 1;
+    wolf::logInfo("[traps] Evil Charm: HP reduced by %u to %u", damage, stats->currentHealth);
+
+    notificationwindow::queue("[Trap] Evil Charm: lost half your health");
+}
+
+void applyInkLossTrap()
+{
+    apgame::collectionData->currentInk = 0;
+    wolf::logInfo("[traps] Dry Inkwell: ink drained");
+
+    notificationwindow::queue("[Trap] Dry Inkwell: ink drained");
+}
+
+void applyFoodLossTrap()
+{
+    apgame::characterStats->currentFood = 0;
+    wolf::logInfo("[traps] Hungry Spirit: food drained");
+
+    notificationwindow::queue("[Trap] Hungry Spirit: Astral Pouch emptied");
+}
+
+} // namespace
+
+std::expected<void, RewardError> grant(int64_t apItemId)
+{
+    switch (apItemId)
+    {
+    case kTrapDamage:
+        applyDamageTrap();
+        break;
+    case kTrapInkLoss:
+        applyInkLossTrap();
+        break;
+    case kTrapFoodLoss:
+        applyFoodLossTrap();
+        break;
+    default:
+        wolf::logWarning("[traps] Unknown trap ID 0x%" PRIX64, apItemId);
+        break;
+    }
+    return {};
+}
+
+} // namespace rewards::traps

--- a/src/okami-apclient/rewards/traps.hpp
+++ b/src/okami-apclient/rewards/traps.hpp
@@ -5,6 +5,12 @@
 
 #include "reward_types.hpp"
 
+/**
+ * @brief Trap reward handler
+ *
+ * Handles trap effects (0x400-0x4FF), which apply negative effects to the
+ * player: Evil Charm (damage), Dry Inkwell (ink drain), Hungry Spirit (food drain).
+ */
 namespace rewards::traps
 {
 
@@ -12,6 +18,14 @@ inline constexpr int64_t kTrapDamage   = 0x400; // Evil Charm:    deal 50% max H
 inline constexpr int64_t kTrapInkLoss  = 0x401; // Dry Inkwell:   drain all current ink
 inline constexpr int64_t kTrapFoodLoss = 0x402; // Hungry Spirit: drain the Astral Pouch (food)
 
+/**
+ * @brief Grant a trap reward
+ *
+ * Applies the trap's negative effect based on the AP item ID.
+ *
+ * @param apItemId The Archipelago item ID (0x400-0x4FF)
+ * @return Success or error
+ */
 [[nodiscard]] std::expected<void, RewardError> grant(int64_t apItemId);
 
 } // namespace rewards::traps

--- a/src/okami-apclient/rewards/traps.hpp
+++ b/src/okami-apclient/rewards/traps.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <expected>
+
+#include "reward_types.hpp"
+
+namespace rewards::traps
+{
+
+inline constexpr int64_t kTrapDamage   = 0x400; // Evil Charm:    deal 50% max HP (never lethal)
+inline constexpr int64_t kTrapInkLoss  = 0x401; // Dry Inkwell:   drain all current ink
+inline constexpr int64_t kTrapFoodLoss = 0x402; // Hungry Spirit: drain the Astral Pouch (food)
+
+[[nodiscard]] std::expected<void, RewardError> grant(int64_t apItemId);
+
+} // namespace rewards::traps

--- a/src/okami-apclient/rewards/traps.hpp
+++ b/src/okami-apclient/rewards/traps.hpp
@@ -14,8 +14,8 @@
 namespace rewards::traps
 {
 
-inline constexpr int64_t kTrapDamage   = 0x400; // Evil Charm:    deal 50% max HP (never lethal)
-inline constexpr int64_t kTrapInkLoss  = 0x401; // Dry Inkwell:   drain all current ink
+inline constexpr int64_t kTrapDamage = 0x400;   // Evil Charm:    deal 50% max HP (never lethal)
+inline constexpr int64_t kTrapInkLoss = 0x401;  // Dry Inkwell:   drain all current ink
 inline constexpr int64_t kTrapFoodLoss = 0x402; // Hungry Spirit: drain the Astral Pouch (food)
 
 /**

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -24,6 +24,7 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/brushes.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/event_flags.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rewards/game_items.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/rewards/traps.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/saveman.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/slotconfig.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ui/loginwindow.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(apclient-testable STATIC
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/rewards/brushes.cpp
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/rewards/event_flags.cpp
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/rewards/game_items.cpp
+    ${CMAKE_SOURCE_DIR}/src/okami-apclient/rewards/traps.cpp
 
     # Check system
     ${CMAKE_SOURCE_DIR}/src/okami-apclient/checkman.cpp


### PR DESCRIPTION
## Description
Adds a couple traps to help fill in junk items. Done to get an intro on some of the Okami rev engineering
Planned follow-ups include yen drain and potentially forced encounters.

## Changes
- Adds traps as rewards
    - Dry Inkwell: removes all ink
    - Evil Charm: does 50% current hp
    - Hungry Spirit: sets current food to 0

## Testing
<!-- How did you test this? -->
- [X] Builds without errors
- [X] Mod loads in-game
- [X] Feature works as expected
- [X] Ran `./format.sh`

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->
relates to https://github.com/Axertin/okami-apclient/issues/42

## Screenshots/Videos
<!-- If applicable, show the changes in action -->
https://www.youtube.com/watch?v=3PjKJcQgqb8

