### PR TITLE
Eventfix hana valley sapling area 

### DIFF
--- a/docs/event-triggers-runtime.md
+++ b/docs/event-triggers-runtime.md
@@ -247,8 +247,56 @@ After starting the sequence in Hana Valley's guardian sapling, there's a dialog 
   return;
 }
 ```
+We simply replace with with an empty function to never prevent the player from leaving the area.
 
 
+## Hana Valley Bloom Tutorial
+The handler for sunrise usage in the sapling room is FUN_184D2410:
+```cpp
+  wk::math::cVec::cVec(local_48);
+  wk::math::cVec::cVec(local_38);
+  wk::math::cVec::cVec(local_28);
+  wk::math::cVec::cVec(local_18);
+  if ((((*(byte *)(WORLD_STATE_POINTER + 0x3dc) & 2) == 0) &&
+      (iVar3 = FUN_1801690c0(&DAT_1808909c0,local_58,0xffffffff,0), iVar3 == 2)) &&
+     (iVar3 = FUN_180169ec0(&DAT_1808909c0), iVar3 == 1)) {
+    DAT_180b6b2ac = DAT_180b6b2ac | 0x40000000;
+    LOCK();
+    UNLOCK();
+    wk::math::cVec::cVec(local_68,(cVec *)&DAT_180b66390);
+    if ((1.0 < local_64) || (local_64 < -1.0)) {
+      if ((*(uint *)(WORLD_STATE_POINTER + 0x3dc) & 0x100) != 0) {
+        set_world_state_bit(0x40031); // Flag 49, this is the branch if you use sunrise without having the crystal in placxe
+        puVar1 = PTR_DAT_1807a8cb0;
+        uVar4 = schedule_callback(PTR_DAT_1807a8cb0 + 0x20,FUN_1804d9490,0xffffffff);
+        register_callback(puVar1,uVar4);
+        return;
+      }
+    }
+    else {
+      if ((*(byte *)(WORLD_STATE_POINTER + 0x3dc) & 0x20) != 0) {
+        set_world_state_bit(0x4001e); // Flag 30, this is the branch if you do have the crystal in place and use sunrise
+        puVar1 = PTR_DAT_1807a8cb0;
+        uVar4 = schedule_callback(PTR_DAT_1807a8cb0 + 0x20,FUN_1804D60E0,
+                                  0xffffffff); // Schedule Callback to the curtscences
+        register_callback(puVar1,uVar4);
+        return;
+      }
+      cVar2 = FUN_1803f3380(PTR_DAT_1807a8cb0,5,0);
+      puVar1 = PTR_DAT_1807a8cb0;
+      if (cVar2 != '\0') {
+        uVar4 = schedule_callback(PTR_DAT_1807a8cb0 + 0x20,FUN_1804d53f0,0xffffffff);
+        register_callback(puVar1,uVar4);
+        return;
+      }
+    }
+    FUN_18014a360(1);
+  }
+```
+
+Our replace first link in approach would have use replace FUN_1804D60E0 with a stub; But this cutscene chain loads in the unbloomed guardian tree. This load doesn't get persisted anywhere while it hasn't been bloomed, meaning reloading the map will remove it forerver, preventing the player form accessing Healed Hana Valley.(*This is likely why the above handler was added to prevent the player from exiting the map.*)
+
+Even is we had a stub that would load in the tree, we'd need the player to have bloom when doing this chain of events to unlock healed Hana Valley, otherwise they'd be locked off it forever. 
 
 ## Stage architecture (one level above TICK)
 

--- a/docs/event-triggers-runtime.md
+++ b/docs/event-triggers-runtime.md
@@ -224,6 +224,32 @@ Confirmed offsets and dispatch order for the Sakuya descent + Water Lily grant +
 
 The bypass installed by `src/okami-apclient/eventfix/kamiki_village.cpp` replaces `FUN_1804c64a0` with a stub that calls `clearCutsceneModeBits()`, `grantBrush(BrushOverlay::water_lily)`, and `transitionStageSubState(0xe)`. The natural chain's per-map state writes (e.g. `KamikiVillage` worldStateBits 11 / 149 / 163) are set elsewhere (trigger volumes, post-bloom scripts); the bypass does not interact with them.
 
+## Hana Valley Guardian Sapling Dialog
+After starting the sequence in Hana Valley's guardian sapling, there's a dialog that prevents you from leaving the area. It's handled by FUN_1804d35d0:
+```cpp
+  if ((((DAT_180b6b2ac >> 0x1e & 1) == 0) &&
+      ((*(uint *)(WORLD_STATE_POINTER + 0x3dc) >> 0xd & 1) != 0)) &&
+     ((*(uint *)(WORLD_STATE_POINTER + 0x3dc) & 2) == 0)) {
+    cVar2 = FUN_1803f3380(PTR_DAT_1807a8cb0,0x11,0,1); // WILD GUESS: This checks the text that's left to display? 
+    if (cVar2 == '\0') {// If none, the state is cleared.
+      clear_world_state_bit(0x40032); // => FUN_1801707c0 
+      return;
+    }
+    // Checks if we're in the guardian sapling sequence
+    if ((*(uint *)(WORLD_STATE_POINTER + 0x3e0) & 0x2000) == 0) {
+      set_world_state_bit(0x40032); => //=> FUN_180170830, set the flag for issun's dialog
+      puVar1 = PTR_DAT_1807a8cb0;
+      uVar3 = FUN_1803ef3c0(PTR_DAT_1807a8cb0 + 0x20,FUN_1804d9490,0xffffffff); // Callback scheduler
+      FUN_1803f3170(puVar1,uVar3);
+      return;
+    }
+  }
+  return;
+}
+```
+
+
+
 ## Stage architecture (one level above TICK)
 
 The CoN TICK has zero static call sites in main.dll. Its only xref is its `.pdata` exception-unwind entry. Despite that, scripts and TICKs in this engine are *not* loaded from external files: there is no separate script bytecode language. Scripts are compiled C++ callbacks baked into main.dll, scheduled by ID via `FUN_1803f35f0(ctx, script_id, ...)` and similar. So the TICK gets installed at runtime through some indirection that we haven't fully traced statically (likely a stage-id -> function-pointer table populated during stage init), but the answer lives somewhere inside main.dll, not in an on-disk script file. The on-disk room files (`data_pc/stN/rXXX.bin`) carry SCA trigger volumes, MSD strings, and per-room asset data, not callback pointers. That said, the *parallel* machinery (the stage descriptor object the TICK eventually drives) is fully visible in the binary.

--- a/src/okami-apclient/eventfix/eventfix.cpp
+++ b/src/okami-apclient/eventfix/eventfix.cpp
@@ -6,8 +6,8 @@
 
 #include "cave_of_nagi.hpp"
 #include "common.hpp"
-#include "kamiki_village.hpp"
 #include "hana_valley.hpp"
+#include "kamiki_village.hpp"
 #include "registry.hpp"
 
 namespace eventfix

--- a/src/okami-apclient/eventfix/eventfix.cpp
+++ b/src/okami-apclient/eventfix/eventfix.cpp
@@ -7,6 +7,7 @@
 #include "cave_of_nagi.hpp"
 #include "common.hpp"
 #include "kamiki_village.hpp"
+#include "hana_valley.hpp"
 #include "registry.hpp"
 
 namespace eventfix
@@ -48,6 +49,7 @@ void initialize()
     int installed = 0;
     installAll(cave_of_nagi::getBypasses(), installed);
     installAll(kamiki_village::getBypasses(), installed);
+    installAll(hana_valley::getBypasses(), installed);
 
     wolf::logInfo("[eventfix] installed %d bypass hooks", installed);
 }

--- a/src/okami-apclient/eventfix/hana_valley.cpp
+++ b/src/okami-apclient/eventfix/hana_valley.cpp
@@ -11,19 +11,31 @@ namespace eventfix::hana_valley
 namespace
 {
 
-// FUN_1804d35d0: this is the handler that prevents you from leaving the area. 
+// FUN_1804d35d0: this is the handler that prevents you from leaving the area.
 // Just remove it so you can leave.
-// Note 1: A bit too extreme, it gets triggered every tick in Hana Valley and tries to get you out of every cutscene in the area
 
 void __fastcall stubIssunBypass()
 {
-    eventfix::clearCutsceneModeBits();
-    wolf::logInfo("[eventfix] Let player leave Guardian sapling area");
+    return;
 }
 
+// FUN_1804D60E0: function shceduled after using sunrise with the Crystal ball in place
+// Hit a deadend with this one. see docs
+
+/*
+void __fastcall stubBloomTutorial()
+{
+    wolf::logDebug("[Eventfix] Bypass bloom tutorial- Bloom Granted");
+    eventfix::clearCutsceneModeBits();
+    eventfix::setStateBit(0x4001F);
+    eventfix::setStateBit(0x40024);
+    eventfix::grantBrush(okami::BrushOverlay::bloom);
+    return;
+}*/
 
 constexpr EventBypass kBypasses[] = {
     {"Hana Valley Guarding Sapling Exit", 0x4D35D0, stubIssunBypass},
+    //{"Hana Valley Bloom Tutorial", 0x04D60E0, stubBloomTutorial}
 };
 
 } // namespace

--- a/src/okami-apclient/eventfix/hana_valley.cpp
+++ b/src/okami-apclient/eventfix/hana_valley.cpp
@@ -1,0 +1,36 @@
+#include "hana_valley.hpp"
+
+#include <okami/brushes.hpp>
+#include <wolf_framework.hpp>
+
+#include "common.hpp"
+
+namespace eventfix::hana_valley
+{
+
+namespace
+{
+
+// FUN_1804d35d0: this is the handler that prevents you from leaving the area. 
+// Just remove it so you can leave.
+// Note 1: A bit too extreme, it gets triggered every tick in Hana Valley and tries to get you out of every cutscene in the area
+
+void __fastcall stubIssunBypass()
+{
+    eventfix::clearCutsceneModeBits();
+    wolf::logInfo("[eventfix] Let player leave Guardian sapling area");
+}
+
+
+constexpr EventBypass kBypasses[] = {
+    {"Hana Valley Guarding Sapling Exit", 0x4D35D0, stubIssunBypass},
+};
+
+} // namespace
+
+std::span<const EventBypass> getBypasses()
+{
+    return kBypasses;
+}
+
+} // namespace eventfix::hana_valley

--- a/src/okami-apclient/eventfix/hana_valley.hpp
+++ b/src/okami-apclient/eventfix/hana_valley.hpp
@@ -7,7 +7,7 @@
 namespace eventfix::hana_valley
 {
 
-// Bypass records for Hana Valley where Issun prevents you from leaving during. See
+// Bypass records for Hana Valley where Issun prevents you from leaving during Guardian Sapling sequence. See
 // docs/event-triggers-runtime.md for the runtime model and chain.
 std::span<const EventBypass> getBypasses();
 

--- a/src/okami-apclient/eventfix/hana_valley.hpp
+++ b/src/okami-apclient/eventfix/hana_valley.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <span>
+
+#include "registry.hpp"
+
+namespace eventfix::hana_valley
+{
+
+// Bypass records for Hana Valley where Issun prevents you from leaving during. See
+// docs/event-triggers-runtime.md for the runtime model and chain.
+std::span<const EventBypass> getBypasses();
+
+} // namespace eventfix::hana_valley

--- a/src/okami-apclient/sources.cmake
+++ b/src/okami-apclient/sources.cmake
@@ -16,6 +16,7 @@ set(okami-apclient_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/cave_of_nagi.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/common.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/eventfix.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/hana_valley.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eventfix/kamiki_village.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gamestate_accessors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/itempatch.cpp


### PR DESCRIPTION
## Description
This allows the player to leave the Guardian Sapling Area in hana Valley during the puzzle sequence 

## Changes
- Added an eventfix for the handler that prevents you from leaving.
- I alsot tried to edit the bloom obtaining sequence to remove the softlock, but hit a deadend. I've added more info in docs  about that.
- 

## Testing
<!-- How did you test this? -->
- [x] Builds without errors
- [x] Mod loads in-game
- [x] Feature works as expected
- [x] Ran `./format.sh`

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos
<!-- If applicable, show the changes in action -->

---

<!-- Thanks for contributing! -->
